### PR TITLE
Retry 429 errors with exponential backoff

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -185,9 +185,8 @@ def giveup(exc):
 
 def on_giveup(details):
     url, params = details['args']
-    LOGGER.error("Giving up on request after %s tries with url %s and params %s",
-                 details['tries'], url, params)
-    sys.exit(1)
+    raise Exception("Giving up on request after {} tries with url {} and params {}" \
+                    .format(details['tries'], url, params))
 
 URL_SOURCE_RE = re.compile(BASE_URL + r'/(\w+)/')
 

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -185,7 +185,8 @@ def giveup(exc):
 
 def on_giveup(details):
     url, params = details['args']
-    LOGGER.error("Giving up on request after {} tries with url {} and params {}".format(details['tries'], url, params))
+    LOGGER.error("Giving up on request after %s tries with url %s and params %s",
+                 details['tries'], url, params)
     sys.exit(1)
 
 URL_SOURCE_RE = re.compile(BASE_URL + r'/(\w+)/')


### PR DESCRIPTION
We have a client experiencing 429 errors: https://trello.com/c/NrM1HyB5/1050-cid-101729-pandadoc-singer-hubspot-replication-not-updating-state

HubSpot recommends retrying such errors after a sleep: https://integrate.hubspot.com/t/reaching-secondly-limit/3966/2

This branch makes the tap retry 429 errors 5 times with exponential backoff.

I tested this by making the tap make requests to an endpoint that always returns 429s:

```
INFO Starting sync. Will sync these streams: ['subscription_changes']
INFO Syncing subscription_changes
{"type": "STATE", "value": {"this_stream": "subscription_changes"}}
{"schema": {"type": "object", "properties": {"recipient": {"type": ["null", "string"]}, "timestamp": {"type": ["null", "string"], "format": "date-time"}, "changes": {"type": ["null", "array"], "items": {"type": ["null", "object"], "properties": {"timestamp": {"type": ["null", "string"], "format": "date-time"}, "changeType": {"type": ["null", "string"]}, "causedByEvent": {"type": ["null", "object"], "properties": {"created": {"type": ["null", "string"], "format": "date-time"}, "id": {"type": ["null", "string"]}}}, "portalId": {"type": ["null", "integer"]}, "source": {"type": ["null", "string"]}, "change": {"type": ["null", "string"]}, "subscriptionId": {"type": ["null", "integer"]}}}}, "portalId": {"type": ["null", "integer"]}}}, "key_properties": ["timestamp", "portalId", "recipient"], "stream": "subscription_changes", "type": "SCHEMA"}
INFO GET http://httpstat.us/429?startTimestamp=1493956800000&limit=1000&endTimestamp=1494043200000
INFO STATS: {"duration": 0.17949318885803223, "http_status_code": 429, "status": "failed"}
INFO GET http://httpstat.us/429?startTimestamp=1493956800000&limit=1000&endTimestamp=1494043200000
INFO STATS: {"duration": 0.08143019676208496, "http_status_code": 429, "status": "failed"}
INFO GET http://httpstat.us/429?startTimestamp=1493956800000&limit=1000&endTimestamp=1494043200000
INFO STATS: {"duration": 0.0833730697631836, "http_status_code": 429, "status": "failed"}
INFO GET http://httpstat.us/429?startTimestamp=1493956800000&limit=1000&endTimestamp=1494043200000
INFO STATS: {"duration": 0.08900976181030273, "http_status_code": 429, "status": "failed"}
INFO GET http://httpstat.us/429?startTimestamp=1493956800000&limit=1000&endTimestamp=1494043200000
INFO STATS: {"duration": 0.1750783920288086, "http_status_code": 429, "status": "failed"}
ERROR Giving up on request after 5 tries with url https://api.hubapi.com/email/public/v1/subscriptions/timeline and params {'startTimestamp': 1493956800000, 'limit': 1000, 'endTimestamp': 1494043200000}
INFO STATS: {"source": "subscription_changes", "status": "failed"}
```