### PR TITLE
Handle 403 during stream sync

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -540,10 +540,10 @@ def do_sync():
 
         try:
             stream.sync() # pylint: disable=not-callable
-        except requests.exceptions.HTTPError as e:
+        except requests.exceptions.HTTPError as ex:
             # 403 here means that the client doesn't have scope for this
             # endpoint and we should pass, otherwise we reraise
-            if e.response.status_code != 403:
+            if ex.response.status_code != 403:
                 raise
 
     STATE[StateFields.this_stream] = None


### PR DESCRIPTION
Since free HubSpot accounts only have access to contacts scope, streams outside of scope return 403 errors. If a 403 occurs during a stream's sync, the tap should move on to the next stream.