### PR TITLE
Check length of args before unpacking

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -184,7 +184,12 @@ def giveup(exc):
         and exc.response.status_code != 429
 
 def on_giveup(details):
-    url, params = details['args']
+    if len(details['args']) == 2:
+        url, params = details['args']
+    else:
+        url = details['args']
+        params = {}
+
     raise Exception("Giving up on request after {} tries with url {} and params {}" \
                     .format(details['tries'], url, params))
 


### PR DESCRIPTION
Since request is sometimes only called with a url, the unpacking in on_giveup needs to first check to see that there are enough args to unpack.