### PR TITLE
Feature/Support more than 10k companies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(name='tap-hubspot',
           'singer-python==1.6.0',
           'requests==2.12.4',
           'backoff==1.3.2',
+          'requests_mock==1.3.0'
       ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
This fixes an issue caused by attempting to replicate data from an account that has more than 10,000 recently-modified companies. Per Hubspot's documentation:

> Note: This endpoint will only return records modified in the last 30 days, or the 10k most recently modified records.  If you need to get all of your companies, please use this endpoint.

We'll continue to use the `/companies/v2/companies/recent/modified` endpoint whenever possible, but we'll fall back to the `/companies/v2/companies/paged` when the response to the first request to the `/modified` endpoint indicates that there are more than 10,000 companies available.