### PR TITLE
Adds support for syncing deal pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This tap:
   - [Contacts](https://docs.stitchdata.com/hc/en-us/articles/URL)
   - [Contact Lists](http://developers.hubspot.com/docs/methods/lists/get_lists)
   - [Deals](http://developers.hubspot.com/docs/methods/deals/get_deals_modified)
+  - [Deal Pipelines](https://developers.hubspot.com/docs/methods/deal-pipelines/get-all-deal-pipelines)
   - [Email Events](http://developers.hubspot.com/docs/methods/email/get_events)
   - [Engagements](https://developers.hubspot.com/docs/methods/engagements/get-all-engagements)
   - [Forms](http://developers.hubspot.com/docs/methods/forms/v2/get_forms)

--- a/tap_hubspot/schemas/deal_pipelines.json
+++ b/tap_hubspot/schemas/deal_pipelines.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "properties": {
+    "pipelineId": {
+      "type": ["null", "string"]
+    },
+    "stages": {
+      "type": ["null", "array"],
+      "items": {
+        "type": "object",
+        "properties": {
+          "stageId": {
+            "type": ["null", "string"]
+          },
+          "label": {
+            "type": ["null", "string"]
+          },
+          "probability": {
+            "type": ["null", "number"]
+          },
+          "active": {
+            "type": ["null", "boolean"]
+          },
+          "displayOrder": {
+            "type": ["null", "integer"]
+          },
+          "closedWon": {
+            "type": ["null", "boolean"]
+          }
+        }
+      }    
+    },
+    "label": {
+      "type": ["null", "string"]
+    },
+    "active": {
+      "type": ["null", "boolean"]
+    },
+    "displayOrder": {
+      "type": ["null", "integer"]
+    }
+  }
+}

--- a/tap_hubspot/schemas/deal_pipelines.json
+++ b/tap_hubspot/schemas/deal_pipelines.json
@@ -38,6 +38,9 @@
     },
     "displayOrder": {
       "type": ["null", "integer"]
+    },
+    "staticDefault": {
+      "type": ["null", "boolean"]      
     }
   }
 }


### PR DESCRIPTION
Please let me know if anything need to be adjusted in this -- deal pipelines don't have any timestamps on them, so they don't appear to have a precedent among the other data currently supported by this tap. I took a shot at what I think would be the best approach. Thanks!