### PR TITLE
Fix/Don't log access token

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -184,7 +184,6 @@ def acquire_access_token_from_refresh_token():
 
 
     resp = requests.post(BASE_URL + "/oauth/v1/token", data=payload)
-    LOGGER.info(resp.content)
     if resp.status_code == 403:
         raise InvalidAuthException(resp.content)
 


### PR DESCRIPTION
Right now we display the access token in the logs. While it's short-lived, this is undesirable for security reasons and not of particular value. This branch thus removes this log line. 