### PR TITLE
 Enables use of a HubSpot HAPIKEY for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This tap:
 
 ## Configuration
 
-This tap requires a `config.json` which specifies details regarding [OAuth 2.0](https://developers.hubspot.com/docs/methods/oauth2/oauth2-overview) authentication, a cutoff date for syncing historical data, and an optional flag which controls collection of anonymous usage metrics. See [config.sample.json](config.sample.json) for an example.
+This tap requires a `config.json` which specifies details regarding [OAuth 2.0](https://developers.hubspot.com/docs/methods/oauth2/oauth2-overview) authentication, a cutoff date for syncing historical data, and an optional flag which controls collection of anonymous usage metrics. See [config.sample.json](config.sample.json) for an example. You may specify an API key instead of OAuth parameters for development purposes, as detailed below.
 
 To run `tap-hubspot` with the configuration file, use this command:
 
@@ -35,7 +35,7 @@ To run `tap-hubspot` with the configuration file, use this command:
 
 As an alternative to OAuth 2.0 authentication during development, you may specify an API key (`HAPIKEY`) to authenticate with the HubSpot API. This should be used only for low-volume development work, as the [HubSpot API Usage Guidelines](https://developers.hubspot.com/apps/api_guidelines) specify that integrations should use OAuth for authentication.
 
-To use an API key, set the `HUBSPOT_HAPIKEY` environment variable with the value of your HAPIKEY when running `tap-hubspot`. Any authentication parameters in your `config.json` will be ignored.
+To use an API key, include a `hapikey` configuration variable in your `config.json` and set it to the value of your HubSpot API key. Any OAuth authentication parameters in your `config.json` **will be ignored** if this key is present!
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ This tap:
 - Outputs the schema for each resource
 - Incrementally pulls data based on the input state
 
+## Configuration
+
+This tap requires a `config.json` which specifies details regarding [OAuth 2.0](https://developers.hubspot.com/docs/methods/oauth2/oauth2-overview) authentication, a cutoff date for syncing historical data, and an optional flag which controls collection of anonymous usage metrics. See [config.sample.json](config.sample.json) for an example.
+
+To run `tap-hubspot` with the configuration file, use this command:
+
+```bash
+› tap-hubspot -c my-config.json
+```
+
+
+## API Key Authentication (for development)
+
+As an alternative to OAuth 2.0 authentication during development, you may specify an API key (`HAPIKEY`) to authenticate with the HubSpot API. This should be used only for low-volume development work, as the [HubSpot API Usage Guidelines](https://developers.hubspot.com/apps/api_guidelines) specify that integrations should use OAuth for authentication.
+
+To use an API key, set the `HUBSPOT_HAPIKEY` environment variable with the value of your HAPIKEY when running `tap-hubspot`. Any authentication parameters in your `config.json` will be ignored.
+
 ---
 
 Copyright &copy; 2017 Stitch

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,0 +1,8 @@
+{
+  "redirect_uri": "https://api.hubspot.com/",
+  "client_id": 123456789000,
+  "client_secret": "my_secret",
+  "refresh_token": "my_token",
+  "start_date": "2017-01-01T00:00:00Z",
+  "disable_collection": false
+}

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -51,6 +51,7 @@ CONFIG = {
     "client_secret": None,
     "refresh_token": None,
     "start_date": None,
+    "hapikey": None
 }
 
 
@@ -231,7 +232,7 @@ def parse_source_from_url(url):
 @utils.ratelimit(9, 1)
 def request(url, params={}):
 
-    hapikey = os.getenv("HUBSPOT_HAPIKEY")
+    hapikey = CONFIG['hapikey']
     if hapikey is None:
         if CONFIG['token_expires'] is None or CONFIG['token_expires'] < datetime.datetime.utcnow():
             acquire_access_token_from_refresh_token()

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -229,13 +229,17 @@ def parse_source_from_url(url):
                       on_giveup=on_giveup,
                       factor=2)
 @utils.ratelimit(9, 1)
-def request(url, params=None):
+def request(url, params={}):
 
-    if CONFIG['token_expires'] is None or CONFIG['token_expires'] < datetime.datetime.utcnow():
-        acquire_access_token_from_refresh_token()
+    hapikey = os.getenv("HUBSPOT_HAPIKEY")
+    if hapikey is None:
+        if CONFIG['token_expires'] is None or CONFIG['token_expires'] < datetime.datetime.utcnow():
+            acquire_access_token_from_refresh_token()
+        headers = {'Authorization': 'Bearer {}'.format(CONFIG['access_token'])}
+    else:
+        params = {**params, **{'hapikey': hapikey}}
+        headers = {}
 
-    params = params or {}
-    headers = {'Authorization': 'Bearer {}'.format(CONFIG['access_token'])}
     if 'user_agent' in CONFIG:
         headers['User-Agent'] = CONFIG['user_agent']
 

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -230,15 +230,16 @@ def parse_source_from_url(url):
                       on_giveup=on_giveup,
                       factor=2)
 @utils.ratelimit(9, 1)
-def request(url, params={}):
+def request(url, params=None):
 
+    params = params or {}
     hapikey = CONFIG['hapikey']
     if hapikey is None:
         if CONFIG['token_expires'] is None or CONFIG['token_expires'] < datetime.datetime.utcnow():
             acquire_access_token_from_refresh_token()
         headers = {'Authorization': 'Bearer {}'.format(CONFIG['access_token'])}
     else:
-        params = {**params, **{'hapikey': hapikey}}
+        params['hapikey'] = hapikey
         headers = {}
 
     if 'user_agent' in CONFIG:


### PR DESCRIPTION
This PR adds one-step configuration for API key usage, intended to ease the development process. It also updates README to explain API key usage and adds a sample config file to the repo. (This partially addresses issue #9.)

The verbiage in the README was drawn from similar language in the [singer-io/target-csv](https://github.com/singer-io/target-csv/blob/2e76485b2d574594387a945aeb7d6e7df4c43645/README.md) repo.

