### PR TITLE
Add additional counters to campaigns

### DIFF
--- a/tap_hubspot/schemas/campaigns.json
+++ b/tap_hubspot/schemas/campaigns.json
@@ -25,6 +25,27 @@
         "sent": {
           "type": ["null", "integer"]
         },
+        "deferred": {
+          "type": ["null", "integer"]
+        },
+        "unsubscribed": {
+          "type": ["null", "integer"]
+        },
+        "statuschange": {
+          "type": ["null", "integer"]
+        },
+        "bounce": {
+          "type": ["null", "integer"]
+        },
+        "mta_dropped": {
+          "type": ["null", "integer"]
+        },
+        "dropped": {
+          "type": ["null", "integer"]
+        },
+        "suppressed": {
+          "type": ["null", "integer"]
+        },
         "click": {
           "type": ["null", "integer"]
         }


### PR DESCRIPTION
There are a number of undocumented fields in the "counters" section of the campaign object:

https://integrate.hubspot.com/t/campaign-events-vs-email-type/8215/2
