### PR TITLE
add check for associations

### DIFF
--- a/tap_hubspot/tests/test_deals.py
+++ b/tap_hubspot/tests/test_deals.py
@@ -1,0 +1,47 @@
+from tap_hubspot import sync_deals
+import unittest
+from unittest.mock import patch, ANY
+
+
+class TestDealsToSync(unittest.TestCase):
+
+    @patch('tap_hubspot.Context.get_catalog_from_id', return_value={"metadata":""})
+    @patch('singer.metadata.to_map', return_value={})
+    @patch('singer.utils.strptime_with_tz')
+    @patch('singer.utils.strftime')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.gen_request', return_value=list())
+    def test_associations_are_not_validated(self,
+        mocked_gen_request,
+        mocked_catalog_from_id,
+        mocked_metadata_map,
+        mocked_utils_strptime,
+        mocked_utils_strftime,
+        mocked_load_schema):
+
+        sync_deals({}, mocked_catalog_from_id)
+
+        expected_param = {'count': 250, 'includeAssociations': False, 'properties': []}
+
+        mocked_gen_request.assert_called_once_with(ANY, ANY, ANY, expected_param, ANY, ANY, ANY, ANY)
+
+
+    @patch('tap_hubspot.Context.get_catalog_from_id', return_value={"metadata":""})
+    @patch('singer.metadata.to_map', return_value={"associations" :{"selected" : True}})
+    @patch('singer.utils.strptime_with_tz')
+    @patch('singer.utils.strftime')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.gen_request', return_value=list())
+    def test_associations_are_validated(self,
+        mocked_gen_request,
+        mocked_catalog_from_id,
+        mocked_metadata_map,
+        mocked_utils_strptime,
+        mocked_utils_strftime,
+        mocked_load_schema):
+
+        sync_deals({}, mocked_catalog_from_id)
+
+        expected_param = {'count': 250, 'includeAssociations': True, 'properties': []}
+
+        mocked_gen_request.assert_called_once_with(ANY, ANY, ANY, expected_param, ANY, ANY, ANY, ANY)


### PR DESCRIPTION
PR for this issue https://github.com/singer-io/tap-hubspot/issues/77

Tested with the following stream:
```
{
  "streams": [
    {
      "tap_stream_id": "deals",
      "stream": "deals",
      "schema": {
        "type": ["null", "object"],
        "selected": "true",
        "additionalProperties": "false",
        "properties": {
          "portalId": {
            "type": [
              "null",
              "integer"
            ]
          },
          "dealId": {
            "type": [
              "null",
              "integer"
            ],
            "selected": "false"
          },
          "associations": {
            "type": ["null", "object"],
            "properties": {
              "associatedVids": {
                "type": ["null", "array"],
                "items": {
                  "type": ["null", "integer"]
                }
              },
              "associatedCompanyIds": {
                "type": ["null", "array"],
                "items": {
                  "type": ["null", "integer"]
                }
              },
              "associatedDealIds": {
                "type": ["null", "array"],
                "items": {
                  "type": ["null", "integer"]
                }
              }
            }
          }
        }
      },
    "metadata": [
        {
          "metadata": {
            "inclusion": "available",
            "table-key-properties": ["portalId"],
            "selected-by-default": true,
            "valid-replication-keys": ["portalId"],
            "schema-name": "deals",
            "selected": true
          },
          "breadcrumb": []
        },
        {
          "metadata": {
            "inclusion": "automatic",
            "selected": true
          },
          "breadcrumb": ["properties", "portalId"]
        },
        {
          "metadata": {
            "inclusion": "available",
            "selected-by-default": true,
            "selected": true
          },
          "breadcrumb": ["properties", "dealId"]
        },
        {
          "metadata": {
            "inclusion": "automatic",
            "selected": true
          },
          "breadcrumb": ["properties", "associations"]
        }
      ]
    }
  ]
}
```

I see that the unit tests that check the **sync** methods (in `test_bookmarks`, `test_offsets`) are either incomplete or broken so I have not added a new unit test. 

Please let me know if you need additional info. 