### PR TITLE
Place custom schema fields at top level.

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -449,7 +449,7 @@ def sync_deals(STATE, ctx):
                 params['includeAssociations'] = True
 
     # Append all the properties fields for deals to the request
-    additional_properties = schema.get("properties").get("properties").get("properties")
+    additional_properties = schema.get("properties")
     for key in additional_properties.keys():
         params['properties'].append(key)
 

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -166,11 +166,7 @@ def load_associated_company_schema():
 def load_schema(entity_name):
     schema = utils.load_json(get_abs_path('schemas/{}.json'.format(entity_name)))
     if entity_name in ["contacts", "companies", "deals"]:
-        custom_schema = get_custom_schema(entity_name)
-        schema['properties']['properties'] = {
-            "type": "object",
-            "properties": custom_schema,
-        }
+        schema['properties'].update(get_custom_schema(entity_name))
 
     if entity_name == "contacts":
         schema['properties']['associated-company'] = load_associated_company_schema()


### PR DESCRIPTION
For `contacts`, `companies`, and `deals`, the large majority of fields are nested within `properties`, coming as they do from `/properties` endpoints of the hubspot API. If these fields were lifted to the top level of each stream, there would be two benefits:

1. Fields could be individually selected within Stitch, instead of only being able to turn on/off all properties.
2. Field names would be shorter, which would be easier on targets with length restrictions, such as postgres.

You might worry about name collisions. We're talking about merging to the same namespace as the schema files on disk, so while the set of all possible property key names may be infinite, the targets are known. For companies:

```json
> cat schema-companies.json |jq '.properties|keys'
[
  "companyId",
  "portalId",
  "properties"
]
```

For deals:
```json
> cat schema-deals.json |jq '.properties|keys'
[
  "associations",
  "dealId",
  "portalId",
  "properties"
]
```

And for contacts:
```json
> cat schema-contacts.json |jq '.properties|keys'
[
  "associated-company",
  "canonical-vid",
  "form-submissions",
  "identity-profiles",
  "is-contact",
  "list-memberships",
  "merge-audits",
  "merged-vids",
  "portal-id",
  "profile-token",
  "profile-url",
  "properties",
  "vid"
]
```

I can't speak for all hubspot accounts' custom properties, but I can show that there are no collisions in our vanilla case:
```bash
> cat schema-companies.json | jq -r '.properties.properties.properties|keys|.[]' > companies-properties
> for w in $(cat schema-companies.json |jq '.properties|keys' | jq -r '.[]'); do grep ^$w$ companies-properties; done | wc -l
       0

> cat schema-deals.json | jq -r '.properties.properties.properties|keys|.[]' > deals-properties
> for w in $(cat schema-deals.json |jq '.properties|keys' | jq -r '.[]'); do grep ^$w$ deals-properties; done | wc -l
       0

> cat schema-contacts.json | jq -r '.properties.properties.properties|keys|.[]' > contacts-properties
> for w in $(cat schema-contacts.json |jq '.properties|keys' | jq -r '.[]'); do grep ^$w$ contacts-properties; done | wc -l
       0

```

A final note: there could be collisions if another entity, such as the `associated-company`, were promoted to the top level, since this is the same schema as `companies`, and `companies` and `contacts` share some properties:
```bash
> for p in $(cat companies-properties); do grep ^$p$ contacts-properties; done| wc -l
      50
```