### PR TITLE
Fix/run all streams each sync

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -758,8 +758,11 @@ def get_streams_to_sync(streams, state):
     target_stream = singer.get_currently_syncing(state)
     result = streams
     if target_stream:
-        result = list(itertools.dropwhile(
+        skipped = list(itertools.takewhile(
             lambda x: x.tap_stream_id != target_stream, streams))
+        rest = list(itertools.dropwhile(
+            lambda x: x.tap_stream_id != target_stream, streams))
+        result = rest + skipped # Move skipped streams to end
     if not result:
         raise Exception('Unknown stream {} in state'.format(target_stream))
     return result

--- a/tap_hubspot/tests/test_get_streams_to_sync.py
+++ b/tap_hubspot/tests/test_get_streams_to_sync.py
@@ -10,23 +10,40 @@ import unittest
 
 class TestGetStreamsToSync(unittest.TestCase):
 
-    def test_get_streams_to_sync_with_no_this_stream(self):
-        streams = [
+    def setUp(self):
+        self.streams = [
             Stream('a', 'a', [], None, None),
             Stream('b', 'b', [], None, None),
             Stream('c', 'c', [], None, None),
         ]
-        state = {'this_stream': None}
-        self.assertEqual(streams, get_streams_to_sync(streams, state))
 
-    def test_get_streams_to_sync_with_this_stream(self):
-        streams = [
-            Stream('a', 'a', [], None, None),
-            Stream('b', 'b', [], None, None),
-            Stream('c', 'c', [], None, None),
-        ]
+    def test_get_streams_to_sync_with_no_this_stream(self):
+        state = {'this_stream': None}
+        self.assertEqual(self.streams, get_streams_to_sync(self.streams, state))
+
+    def test_get_streams_to_sync_with_first_stream(self):
+        state = {'currently_syncing': 'a'}
+
+        result = get_streams_to_sync(self.streams, state)
+
+        parsed_result = [s.tap_stream_id for s in result]
+        self.assertEqual(parsed_result, ['a', 'b', 'c'])
+
+    def test_get_streams_to_sync_with_middle_stream(self):
         state = {'currently_syncing': 'b'}
-        self.assertEqual(streams[1:], list(get_streams_to_sync(streams, state)))
+
+        result = get_streams_to_sync(self.streams, state)
+
+        parsed_result = [s.tap_stream_id for s in result]
+        self.assertEqual(parsed_result, ['b', 'c', 'a'])
+
+    def test_get_streams_to_sync_with_last_stream(self):
+        state = {'currently_syncing': 'c'}
+
+        result = get_streams_to_sync(self.streams, state)
+
+        parsed_result = [s.tap_stream_id for s in result]
+        self.assertEqual(parsed_result, ['c', 'a', 'b'])
 
     def test_parse_source_from_url_succeeds(self):
         url = "https://api.hubapi.com/companies/v2/companies/recent/modified"


### PR DESCRIPTION
When the state has a `currently_syncing` stream, indicating that the previous run was interrupted, the tap would just run until it finished the list of streams. This PR makes it so that ALL streams are attempted from every run.

If a "currently_syncing" stream is found, the streams that come before that one are **appended to the end of the list**, instead of dropped.