### PR TITLE
Add lookback duration for engagements

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -106,7 +106,7 @@ def get_previous_time_window(state, tap_stream_id):
     return singer.get_bookmark(state, tap_stream_id, "last_sync_duration")
 
 def write_stream_duration(state, tap_stream_id, start, end):
-    duration = (start - end).total_seconds()
+    duration = (end - start).total_seconds()
     return singer.write_bookmark(state, tap_stream_id, "last_sync_duration", duration)
 
 def get_url(endpoint, **kwargs):

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -708,6 +708,8 @@ def sync_engagements(STATE, ctx):
     current_sync_start = utils.now()
     if has_bookmark(STATE, "engagements", bookmark_key) and \
        last_sync_duration is not None:
+        LOGGER.info(("Last sync of engagements lasted {} seconds. Adjusting bookmark by this"
+                     "amount to account for race conditions with record updates."))
         start = start - datetime.timedelta(seconds=last_sync_duration)
     max_bk_value = start
     LOGGER.info("sync_engagements from %s", start)

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -708,9 +708,10 @@ def sync_engagements(STATE, ctx):
     current_sync_start = utils.now()
     if has_bookmark(STATE, "engagements", bookmark_key) and \
        last_sync_duration is not None:
-        LOGGER.info(("Last sync of engagements lasted {} seconds. Adjusting bookmark by this"
-                     "amount to account for race conditions with record updates."))
-        start = start - datetime.timedelta(seconds=last_sync_duration)
+        LOGGER.info(("Last sync of engagements lasted {} seconds. Adjusting bookmark by this "
+                     "amount to account for race conditions with record updates.").format(last_sync_duration))
+        start = utils.strptime_to_utc(start) - datetime.timedelta(seconds=last_sync_duration)
+        start = utils.strftime(start)
     max_bk_value = start
     LOGGER.info("sync_engagements from %s", start)
 

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -704,7 +704,7 @@ def sync_engagements(STATE, ctx):
     # be captured, in order to combat this, we must save a lookback window
     # that handles the duration of time that this stream was last syncing,
     # and look back by that amount on the next sync
-    last_sync_duration = utils.strptime_to_utc(get_previous_time_window(STATE, "engagements"))
+    last_sync_duration = get_previous_time_window(STATE, "engagements")
     current_sync_start = utils.now()
     if has_bookmark(STATE, "engagements", bookmark_key) and \
        last_sync_duration is not None:


### PR DESCRIPTION
This is a strange situation that can arise when records are vigorously updated while syncing the engagements stream. There are a few things that contribute to this, given the syncing strategy:

1. There's no way to query based on `lastUpdated`, so the full data set must be inspected each run, and records emitted based on bookmark value.
2. Because of this, the `max_bookmark` is saved through each run and written to state after the whole dataset has been seen.
3. The recordset isn't frozen with the first request, like some pagination strategies, so records may be updated out of the time range as the sync progresses.

**The Situation**

The effect of that is this potential situation:

T0: Start engagements sync
T1: Get record R1 and sync, update max_bookmark to R1[lastUpdated]
T2: Record R1 is updated
T3: Record R2 is updated
T4: Sync record R2, update max_bookmark to R2[lastUpdated]
T5: Finish engagements sync and save max_bookmark to emit records from for the next time around

In this situation, the update to record R1 that occurred at T2 is skipped on the next sync, since it's `lastUpdated` value is lower than the bookmark, saved from T2 as "max".

**Mitigation**

In order to mitigate this, the duration of the engagements sync is stored in `STATE` under `last_sync_duration`, when present, this value will determine the amount of time (in seconds) that the bookmark should be pushed towards the past to catch any records that were updated as described above.