### PR TITLE
Change backoff to 10 second intervals

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -237,13 +237,14 @@ def parse_source_from_url(url):
     return None
 
 
-@backoff.on_exception(backoff.expo,
-                      requests.exceptions.RequestException,
+@backoff.on_exception(backoff.constant,
+                      (requests.exceptions.RequestException,
+                       requests.exceptions.HTTPError),
                       max_tries=5,
+                      jitter=None,
                       giveup=giveup,
                       on_giveup=on_giveup,
-                      factor=2)
-@utils.ratelimit(9, 1)
+                      interval=10)
 def request(url, params=None):
 
     params = params or {}


### PR DESCRIPTION
Occasionally the tap would receive `429`s, retry `5` times, and then fail.

According to the [Hubspot documentation](https://developers.hubspot.com/apps/api_guidelines), the `429` comes back when we make too many calls in the span of 10 seconds. 

My fix here is to backoff for exactly 10 seconds when we receive the `429`. This was accomplished by changing the backoff strategy from exponential to constant with an interval of 10. To get exactly 10 seconds, the `jitter` was set to `None`.

I also removed the `utils.ratelimit` because in testing, I noticed it was could interfere with the backoff handling. 