### PR TITLE
Fix Missed Updates Over Multiple Syncs

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -106,9 +106,9 @@ def write_current_sync_start(state, tap_stream_id, start):
 
 def clean_state(state):
     """ Clear deprecated keys out of state. """
-    for stream, bookmark_map in STATE.get("bookmarks", {}).items():
+    for stream, bookmark_map in state.get("bookmarks", {}).items():
         if "last_sync_duration" in bookmark_map:
-            STATE[stream].pop("last_sync_duration", None)
+            state[stream].pop("last_sync_duration", None)
 
 def get_url(endpoint, **kwargs):
     if endpoint not in ENDPOINTS:

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -98,15 +98,17 @@ def get_start(state, tap_stream_id, bookmark_key):
         return CONFIG['start_date']
     return current_bookmark
 
-def has_bookmark(state, tap_stream_id, bookmark_key):
-    return singer.get_bookmark(state, tap_stream_id, bookmark_key) is not None
+def get_current_sync_start(state, tap_stream_id):
+    return utils.strptime_to_utc(singer.get_bookmark(state, tap_stream_id, "current_sync_start"))
 
-def get_previous_time_window(state, tap_stream_id):
-    return singer.get_bookmark(state, tap_stream_id, "last_sync_duration")
+def write_current_sync_start(state, tap_stream_id, start):
+    return singer.write_bookmark(state, tap_stream_id, "current_sync_start", utils.strftime(start))
 
-def write_stream_duration(state, tap_stream_id, start, end):
-    duration = (end - start).total_seconds()
-    return singer.write_bookmark(state, tap_stream_id, "last_sync_duration", duration)
+def clean_state(state):
+    """ Clear deprecated keys out of state. """
+    for stream, bookmark_map in STATE.get("bookmarks", {}).items():
+        if "last_sync_duration" in bookmark_map:
+            STATE[stream].pop("last_sync_duration", None)
 
 def get_url(endpoint, **kwargs):
     if endpoint not in ENDPOINTS:
@@ -407,6 +409,16 @@ def sync_companies(STATE, ctx):
     schema = load_schema('companies')
     singer.write_schema("companies", schema, ["companyId"], [bookmark_key], catalog.get('stream_alias'))
 
+    # Because this stream doesn't query by `lastUpdated`, it cycles
+    # through the data set every time. The issue with this is that there
+    # is a race condition by which records may be updated between the
+    # start of this table's sync and the end, causing some updates to not
+    # be captured, in order to combat this, we must store the current
+    # sync's start in the state and not move the bookmark past this value.
+    current_sync_start = get_current_sync_start(STATE, "companies") or utils.now()
+    STATE = write_current_sync_start(STATE, "companies", current_sync_start)
+    singer.write_state(STATE)
+
     url = get_url("companies_all")
     max_bk_value = start
     if CONTACTS_BY_COMPANY in ctx.selected_stream_ids:
@@ -436,7 +448,10 @@ def sync_companies(STATE, ctx):
                 if CONTACTS_BY_COMPANY in ctx.selected_stream_ids:
                     STATE = _sync_contacts_by_company(STATE, record['companyId'])
 
-    STATE = singer.write_bookmark(STATE, 'companies', bookmark_key, utils.strftime(max_bk_value))
+    # Don't bookmark past the start of this sync to account for updated records during the sync.
+    new_bookmark = min(max_bk_value, current_sync_start)
+    STATE = singer.write_bookmark(STATE, 'companies', bookmark_key, utils.strftime(new_bookmark))
+    STATE = write_current_sync_start(STATE, 'companies', None)
     singer.write_state(STATE)
     return STATE
 
@@ -712,17 +727,12 @@ def sync_engagements(STATE, ctx):
     # through the data set every time. The issue with this is that there
     # is a race condition by which records may be updated between the
     # start of this table's sync and the end, causing some updates to not
-    # be captured, in order to combat this, we must save a lookback window
-    # that handles the duration of time that this stream was last syncing,
-    # and look back by that amount on the next sync
-    last_sync_duration = get_previous_time_window(STATE, "engagements")
-    current_sync_start = utils.now()
-    if has_bookmark(STATE, "engagements", bookmark_key) and \
-       last_sync_duration is not None:
-        LOGGER.info(("Last sync of engagements lasted {} seconds. Adjusting bookmark by this "
-                     "amount to account for race conditions with record updates.").format(last_sync_duration))
-        start = utils.strptime_to_utc(start) - datetime.timedelta(seconds=last_sync_duration)
-        start = utils.strftime(start)
+    # be captured, in order to combat this, we must store the current
+    # sync's start in the state and not move the bookmark past this value.
+    current_sync_start = get_current_sync_start(STATE, "engagements") or utils.now()
+    STATE = write_current_sync_start(STATE, "engagements", current_sync_start)
+    singer.write_state(STATE)
+
     max_bk_value = start
     LOGGER.info("sync_engagements from %s", start)
 
@@ -747,9 +757,10 @@ def sync_engagements(STATE, ctx):
                 if record['engagement'][bookmark_key] >= max_bk_value:
                     max_bk_value = record['engagement'][bookmark_key]
 
-    STATE = singer.write_bookmark(STATE, 'engagements', bookmark_key, max_bk_value)
-    # Write duration for next sync's lookback window
-    STATE = write_stream_duration(STATE, 'engagements', current_sync_start, utils.now())
+    # Don't bookmark past the start of this sync to account for updated records during the sync.
+    new_bookmark = min(max_bk_value, current_sync_start)
+    STATE = singer.write_bookmark(STATE, 'engagements', bookmark_key, new_bookmark)
+    STATE = write_current_sync_start(STATE, 'engagements', None)
     singer.write_state(STATE)
     return STATE
 
@@ -818,6 +829,9 @@ def get_selected_streams(remaining_streams, annotated_schema):
     return selected_streams
 
 def do_sync(STATE, catalogs):
+    # Clear out keys that are no longer used
+    clean_state(STATE)
+
     ctx = Context(catalogs)
     validate_dependencies(ctx)
 


### PR DESCRIPTION
In [this commit](https://github.com/singer-io/tap-hubspot/commit/c2bb3b00e45d1733f58c07a4d38985a39c859aa5), I added a lookback window to engagements. There's another case where this same sort of thing can happen due to the way the companies API endpoint works (same as engagements, e.g., no sorting, no query-by-updated-at, etc.).

However, depending on the length of each tap-run, the existing pattern won't work across multiple runs, since it doesn't save any state until the end of the stream's sync.

**The Solution Presented Here**
The original pattern was to calculate a lookback window consisting of the `end - start` of the most recent sync. However, this PR modifies that to forcing the bookmark to be the `min(current_sync_start, max_bk_seen)` at the end of a sync, and saving `current_sync_start` into the state.

This is equivalent, and because `current_sync_start` is present in the state, it works across multiple interrupted invocations of the tap, so it should be more resilient to failure.