### PR TITLE
only append properties to deals request if that field is selected

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -486,8 +486,8 @@ def sync_deals(STATE, ctx):
                 params['includeAssociations'] = True
 
     # Append all the properties fields for deals to the request if
-    # properties is selected
-    if mdata.get(('properties', 'properties')).get('selected'):
+    # properties is selectedOB
+    if mdata.get(('properties', 'properties'), {}).get('selected'):
         additional_properties = schema.get("properties").get("properties").get("properties")
         for key in additional_properties.keys():
             params['properties'].append(key)

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -485,10 +485,12 @@ def sync_deals(STATE, ctx):
             if (assoc_mdata.get('selected') and assoc_mdata.get('selected') == True):
                 params['includeAssociations'] = True
 
-    # Append all the properties fields for deals to the request
-    additional_properties = schema.get("properties").get("properties").get("properties")
-    for key in additional_properties.keys():
-        params['properties'].append(key)
+    # Append all the properties fields for deals to the request if
+    # properties is selected
+    if mdata.get(('properties', 'properties')).get('selected'):
+        additional_properties = schema.get("properties").get("properties").get("properties")
+        for key in additional_properties.keys():
+            params['properties'].append(key)
 
     url = get_url('deals_all')
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:


### PR DESCRIPTION
# Description of change
When hitting the `deals` endpoint, the tap was always appending all fields nested under `properties` to the request, regardless of whether `properties` was selected or not.  This PR only appends the fields if `properties` is selected.

# Manual QA steps
 - Cloned the connection of a customer who was hitting an error because the request url was too long, even though they did not have `properties` selected.  After making the change, their connection no longer hits this error.  Verified that if `properties` is selected, the nested fields are appended and the connection hits the error.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
