### PR TITLE
bump version to 2.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.6.4
+  * When making `deals` requests, only attach `properties` if selected [#102](https://github.com/singer-io/tap-hubspot/pull/102)
+
 ## 2.6.3
   * Use the metadata library better
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-hubspot',
-      version='2.6.3',
+      version='2.6.4',
       description='Singer.io tap for extracting data from the HubSpot API',
       author='Stitch',
       url='http://singer.io',


### PR DESCRIPTION
# Description of change
Bump version to 2.6.4

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
