### PR TITLE
Move properties fields to top level

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           command: |
             source ~/.virtualenvs/tap-hubspot/bin/activate
             pip install nose
-            nosetests
+            nosetests tap_hubspot/tests
       - run:
           name: 'JSON Validator'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,13 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-a-test --tap=tap-hubspot \
-                       --target=target-stitch \
-                       --orchestrator=stitch-orchestrator \
-                       --email=harrison+sandboxtest@stitchdata.com \
-                       --password=$SANDBOX_PASSWORD \
-                       --client-id=50 \
-                       tap_tester.suites.hubspot
+            run-test --tap=tap-hubspot \
+                     --target=target-stitch \
+                     --orchestrator=stitch-orchestrator \
+                     --email=harrison+sandboxtest@stitchdata.com \
+                     --password=$SANDBOX_PASSWORD \
+                     --client-id=50 \
+                     tests
 workflows:
   version: 2
   commit:

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -300,7 +300,7 @@ def request(url, params=None):
 def lift_properties_and_versions(record):
     for key, value in record.get('properties', {}).items():
         computed_key = "property_{}".format(key)
-        versions = value.pop('versions', None)
+        versions = value.get('versions')
         record[computed_key] = value
 
         if versions:

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -502,7 +502,7 @@ def sync_deals(STATE, ctx):
                 params['includeAssociations'] = True
 
     # Append all the properties fields for deals to the request
-    additional_properties = [k for k in schema.get("properties").keys() if k.startswith("property")]
+    additional_properties = [k for k in schema.get("properties").keys() if k.startswith("property_")]
     for prop in additional_properties:
         if mdata.get(('properties', prop), {}).get('selected'):
             params['properties'].append(prop.replace('property_', ''))

--- a/tap_hubspot/schemas/deals.json
+++ b/tap_hubspot/schemas/deals.json
@@ -7,6 +7,9 @@
     "dealId": {
       "type": ["null", "integer"]
     },
+    "isDeleted": {
+      "type": ["null", "boolean"]
+    },
     "associations": {
       "type": ["null", "object"],
       "properties": {

--- a/tap_hubspot/schemas/versions.json
+++ b/tap_hubspot/schemas/versions.json
@@ -1,0 +1,30 @@
+{
+  "type": "array",
+  "items": {
+    "type": ["null", "object"],
+    "properties": {
+      "name": {
+        "type": ["null", "string"]
+      },
+      "value": {
+        "type": ["null", "string"]
+      },
+      "timestamp": {
+        "type": ["null", "string"],
+        "format": "date-time"
+      },
+      "source": {
+        "type": ["null", "string"]
+      },
+      "sourceId": {
+        "type": ["null", "string"]
+      },
+      "sourceVid": {
+        "type": ["null", "array"],
+        "items": {
+          "type": ["null", "string"]
+        }
+      }
+    }  
+  }
+}

--- a/tests/test_hubspot_bookmarks1.py
+++ b/tests/test_hubspot_bookmarks1.py
@@ -1,0 +1,240 @@
+from tap_tester.scenario import (SCENARIOS)
+import tap_tester.connections as connections
+import tap_tester.menagerie   as menagerie
+import tap_tester.runner      as runner
+import os
+import datetime
+import unittest
+from functools import reduce
+from singer import utils
+import datetime
+import pdb
+
+class HubSpotBookmarks1(unittest.TestCase):
+    def setUp(self):
+        missing_envs = [x for x in [os.getenv('TAP_HUBSPOT_REDIRECT_URI'),
+                                    os.getenv('TAP_HUBSPOT_CLIENT_ID'),
+                                    os.getenv('TAP_HUBSPOT_CLIENT_SECRET'),
+                                    os.getenv('TAP_HUBSPOT_REFRESH_TOKEN')] if x == None]
+        if len(missing_envs) != 0:
+            #pylint: disable=line-too-long
+            raise Exception("set TAP_HUBSPOT_REDIRECT_URI, TAP_HUBSPOT_CLIENT_ID, TAP_HUBSPOT_CLIENT_SECRET, TAP_HUBSPOT_REFRESH_TOKEN")
+
+    def name(self):
+        return "tap_tester_hub_bookmarks_1"
+
+    def tap_name(self):
+        return "tap-hubspot"
+
+    def get_type(self):
+        return "platform.hubspot"
+
+    def get_credentials(self):
+        return {'refresh_token': os.getenv('TAP_HUBSPOT_REFRESH_TOKEN'),
+                'client_secret': os.getenv('TAP_HUBSPOT_CLIENT_SECRET'),
+                'redirect_uri':  os.getenv('TAP_HUBSPOT_REDIRECT_URI'),
+                'client_id':     os.getenv('TAP_HUBSPOT_CLIENT_ID')}
+
+    def expected_pks(self):
+        return {
+            "subscription_changes" : {"timestamp", "portalId", "recipient"},
+            "email_events" :         {'id'},
+            "forms" :                {"guid"},
+            "workflows" :            {"id"},
+            "owners" :               {"ownerId"},
+            "campaigns" :            {"id"},
+            "contact_lists":         {"listId"},
+            "contacts" :             {'vid'},
+            "companies":             {"companyId"},
+            "deals":                 {"dealId"},
+            "engagements":           {"engagement_id"},
+            "contacts_by_company" : {"company-id", "contact-id"},
+            "deal_pipelines" : {"pipelineId"},
+        }
+
+    def acceptable_bookmarks(self):
+        return {
+            "subscription_changes",
+            "email_events",
+            "forms",
+            "workflows",
+            "owners",
+            "campaigns",
+            "contact_lists",
+            "contacts",
+            "companies",
+            "deals",
+            "engagements",
+            "contacts_by_company",
+        }
+
+    def expected_check_streams(self):
+        return {
+            "subscription_changes",
+            "email_events",
+            "forms",
+            "workflows",
+            "owners",
+            "campaigns",
+            "contact_lists",
+            "contacts",
+            "companies",
+            "deals",
+            "engagements",
+            "deal_pipelines",
+            "contacts_by_company"
+        }
+
+    def expected_sync_streams(self):
+        return {
+            "subscription_changes",
+            "email_events",
+            "forms",
+            "workflows",
+            "owners",
+            "campaigns",
+            "contact_lists",
+            "contacts",
+            "companies",
+            "deals",
+            "engagements",
+            "contacts_by_company",
+            "deal_pipelines",
+        }
+
+    def expected_offsets(self):
+        return {'deals': {},
+                'contact_lists': {},
+                'email_events' : {},
+                'contacts' : {},
+                'campaigns' : {},
+                'subscription_changes' : {},
+                'engagements': {},
+                'companies' : {}}
+
+
+    def record_to_bk_value(self, stream, record):
+        # Deals and Companies records have been transformed so the bookmark
+        # is prefixed by "property_". There is a nest map structure beneath the value.
+
+        if stream == 'companies':
+            bk_value = record.get('property_hs_lastmodifieddate') or record.get('createdate')
+            if bk_value is None:
+                return None
+            return bk_value.get('value')
+
+        if stream == 'deals':
+            bk_value = record.get('property_hs_lastmodifieddate')
+            if bk_value is None:
+                return None
+            return bk_value.get('value')
+        else:
+            bk_columns = self.expected_bookmarks().get(stream, [])
+            if len(bk_columns) == 0:
+                return None
+
+            bk_column = bk_columns[0] #only consider first bookmark
+
+            bk_value = record.get(bk_column)
+            if not bk_value:
+                raise Exception("Record received without bookmark value for stream {}: {}".format(stream, record))
+            return utils.strftime(utils.strptime_with_tz(bk_value))
+
+    def expected_bookmarks(self):
+        return {'deals' :         ['hs_lastmodifieddate'],
+                'contact_lists' : ['updatedAt'],
+                'email_events' :  ['startTimestamp'],
+                # 'contacts':       ['versionTimestamp'],
+                'workflows':      ['updatedAt'],
+                'campaigns':      [],
+                'contacts_by_company' : [],
+                'owners' :        ['updatedAt'],
+                'subscription_changes':  ['startTimestamp'],
+                'engagements' :          ['lastUpdated'],
+                'companies'  :           ['hs_lastmodifieddate'],
+                'forms'      :           ['updatedAt'] }
+
+
+    def get_properties(self):
+        return {'start_date' : '2017-05-01 00:00:00'}
+
+    def perform_field_selection(self, conn_id, catalog):
+        schema = menagerie.select_catalog(conn_id, catalog)
+
+        return {'key_properties' :     catalog.get('key_properties'),
+                'schema' :             schema,
+                'tap_stream_id':       catalog.get('tap_stream_id'),
+                'replication_method' : catalog.get('replication_method'),
+                'replication_key'    : catalog.get('replication_key')}
+
+    def test_run(self):
+        conn_id = connections.ensure_connection(self)
+
+        #run in check mode
+        check_job_name = runner.run_check_mode(self, conn_id)
+
+        #verify check  exit codes
+        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
+
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
+
+        found_catalog_names = set(map(lambda c: c['tap_stream_id'], found_catalogs))
+
+        diff = self.expected_check_streams().symmetric_difference( found_catalog_names )
+        self.assertEqual(len(diff), 0, msg="discovered schemas do not match: {}".format(diff))
+        print("discovered schemas are kosher")
+
+        # Select all Catalogs
+        for catalog in found_catalogs:
+            connections.select_catalog_and_fields_via_metadata(conn_id, catalog, menagerie.get_annotated_schema(conn_id, catalog['stream_id']))
+
+        #clear state
+        menagerie.set_state(conn_id, {})
+
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+
+        #verify tap and target exit codes
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+
+        record_count_by_stream = runner.examine_target_output_file(self, conn_id, self.expected_sync_streams(), self.expected_pks())
+        replicated_row_count =  reduce(lambda accum,c : accum + c, record_count_by_stream.values())
+        self.assertGreater(replicated_row_count, 0, msg="failed to replicate any data: {}".format(record_count_by_stream))
+        print("total replicated row count: {}".format(replicated_row_count))
+
+        max_bookmarks_from_records = runner.get_most_recent_records_from_target(self, self.expected_bookmarks(), self.get_properties()['start_date'])
+
+        start_of_today =  utils.strftime(datetime.datetime(datetime.datetime.utcnow().year, datetime.datetime.utcnow().month, datetime.datetime.utcnow().day, 0, 0, 0, 0, datetime.timezone.utc))
+        max_bookmarks_from_records['subscription_changes'] = start_of_today
+        max_bookmarks_from_records['email_events'] = start_of_today
+
+
+        #if we didn't replicate data, the bookmark should be the start_date
+        for k in self.expected_bookmarks().keys():
+            if max_bookmarks_from_records.get(k) is None:
+                max_bookmarks_from_records[k] = utils.strftime(datetime.datetime(2017, 5, 1, 0, 0, 0, 0, datetime.timezone.utc))
+
+        state = menagerie.get_state(conn_id)
+        bookmarks = state.get('bookmarks')
+        bookmark_streams = set(state.get('bookmarks').keys())
+
+        #verify bookmarks and offsets
+        for k,v in sorted(list(self.expected_bookmarks().items())):
+            for w in v:
+                bk_value = bookmarks.get(k,{}).get(w)
+                self.assertEqual(utils.strptime_with_tz(bk_value), utils.strptime_with_tz(max_bookmarks_from_records[k]), "Bookmark {} ({}) for stream {} should have been updated to {}".format(bk_value, w, k, max_bookmarks_from_records[k]))
+                print("bookmark {}({}) updated to {} from max record value {}".format(k, w, bk_value, max_bookmarks_from_records[k]))
+
+        for k,v in self.expected_offsets().items():
+            self.assertEqual(bookmarks.get(k,{}).get('offset', {}), v, msg="unexpected offset found for stream {} {}. state: {}".format(k, v, state))
+            print("offsets {} cleared".format(k))
+
+        diff = bookmark_streams.difference(self.acceptable_bookmarks())
+        self.assertEqual(len(diff), 0, msg="Unexpected bookmarks: {} Expected: {} Actual: {}".format(diff, self.acceptable_bookmarks(), bookmarks))
+
+        self.assertEqual(state.get('currently_syncing'), None,"Unexpected `currently_syncing` bookmark value: {} Expected: None".format(state.get('currently_syncing')))
+
+
+SCENARIOS.add(HubSpotBookmarks1)

--- a/tests/test_hubspot_bookmarks2.py
+++ b/tests/test_hubspot_bookmarks2.py
@@ -1,0 +1,198 @@
+from tap_tester.scenario import (SCENARIOS)
+import tap_tester.connections as connections
+import tap_tester.menagerie   as menagerie
+import tap_tester.runner      as runner
+import os
+import unittest
+
+class HubSpotBookmarks2(unittest.TestCase):
+    def setUp(self):
+        missing_envs = [x for x in [os.getenv('TAP_HUBSPOT_REDIRECT_URI'),
+                                    os.getenv('TAP_HUBSPOT_CLIENT_ID'),
+                                    os.getenv('TAP_HUBSPOT_CLIENT_SECRET'),
+                                    os.getenv('TAP_HUBSPOT_REFRESH_TOKEN')] if x == None]
+        if len(missing_envs) != 0:
+            #pylint: disable=line-too-long
+            raise Exception("set TAP_HUBSPOT_REDIRECT_URI, TAP_HUBSPOT_CLIENT_ID, TAP_HUBSPOT_CLIENT_SECRET, TAP_HUBSPOT_REFRESH_TOKEN")
+
+    def name(self):
+        return "tap_tester_hub_bookmarks_2"
+
+    def tap_name(self):
+        return "tap-hubspot"
+
+    def get_type(self):
+        return "platform.hubspot"
+
+    def get_credentials(self):
+        return {'refresh_token': os.getenv('TAP_HUBSPOT_REFRESH_TOKEN'),
+                'client_secret': os.getenv('TAP_HUBSPOT_CLIENT_SECRET'),
+                'redirect_uri':  os.getenv('TAP_HUBSPOT_REDIRECT_URI'),
+                'client_id':     os.getenv('TAP_HUBSPOT_CLIENT_ID')}
+
+    def expected_pks(self):
+        return {
+            "subscription_changes" : {"timestamp", "portalId", "recipient"},
+            "email_events" :         {'id'},
+            "forms" :                {"guid"},
+            "workflows" :            {"id"},
+            "owners" :               {"ownerId"},
+            "campaigns" :            {"id"},
+            "contact_lists":         {"listId"},
+            "contacts" :             {'vid'},
+            "companies":             {"companyId"},
+            "deals":                 {"dealId"},
+            "engagements":           {"engagement_id"},
+            "contacts_by_company" : {"company-id", "contact-id"},
+            "deal_pipelines" : {"pipelineId"},
+        }
+
+    def expected_check_streams(self):
+        return {
+            "subscription_changes",
+            "email_events",
+            "forms",
+            "workflows",
+            "owners",
+            "campaigns",
+            "contact_lists",
+            "contacts",
+            "companies",
+            "deals",
+            "engagements",
+            "deal_pipelines",
+            "contacts_by_company"}
+
+    def expected_sync_streams(self):
+        return {
+            "subscription_changes",
+            "email_events",
+            "forms",
+            "workflows",
+            "owners",
+            "campaigns",
+            "contact_lists",
+            "contacts",
+            "companies",
+            "deals",
+            "engagements",
+            "contacts_by_company",
+            "deal_pipelines"}
+
+    def expected_offsets(self):
+        return {'deals': {},
+                'contact_lists': {},
+                'email_events' : {},
+                'contacts' : {},
+                'campaigns' : {},
+                'subscription_changes' : {},
+                'engagements': {},
+                'companies' : {}}
+
+    def expected_bookmarks(self):
+        return {'deals' :         ['hs_lastmodifieddate'],
+                'contact_lists' : ['updatedAt'],
+                'email_events' :  ['startTimestamp'],
+                # 'contacts':       ['lastmodifieddate'],
+                'workflows':      ['updatedAt'],
+                'campaigns':      [],
+                'owners' :        ['updatedAt'],
+                'subscription_changes':  ['startTimestamp'],
+                'engagements' :          ['lastUpdated'],
+                'companies'  :           ['hs_lastmodifieddate'],
+                'forms'      :           ['updatedAt'] }
+
+
+    def get_properties(self):
+        return {'start_date' : '2017-05-01 00:00:00'}
+
+    def perform_field_selection(self, conn_id, catalog):
+        schema = menagerie.select_catalog(conn_id, catalog)
+
+        return {'key_properties' :     catalog.get('key_properties'),
+                'schema' :             schema,
+                'tap_stream_id':       catalog.get('tap_stream_id'),
+                'replication_method' : catalog.get('replication_method'),
+                'replication_key'    : catalog.get('replication_key')}
+
+    def test_run(self):
+        conn_id = connections.ensure_connection(self)
+
+        #run in check mode
+        check_job_name = runner.run_check_mode(self, conn_id)
+
+        #verify check  exit codes
+        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
+
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
+
+        found_catalog_names = set(map(lambda c: c['tap_stream_id'], found_catalogs))
+
+        diff = self.expected_check_streams().symmetric_difference( found_catalog_names )
+        self.assertEqual(len(diff), 0, msg="discovered schemas do not match: {}".format(diff))
+        print("discovered schemas are kosher")
+
+        #select all catalogs
+        for catalog in found_catalogs:
+            connections.select_catalog_and_fields_via_metadata(conn_id, catalog, menagerie.get_annotated_schema(conn_id, catalog['stream_id']))
+
+        future_time = "2050-01-01T00:00:00.000000Z"
+
+        #clear state
+        future_bookmarks = {"currently_syncing" : None,
+                            "bookmarks":  {"contacts" : {"offset" : {},
+                                                         "versionTimestamp" :  future_time},
+                                           "subscription_changes" : {"startTimestamp" : future_time,
+                                                                     "offset" :  {}},
+                                           "campaigns" :  {"offset" : {}},
+                                           "forms" : {"updatedAt" :  future_time},
+                                           "deals" :  {"offset" :  {},
+                                                       "hs_lastmodifieddate" :  future_time},
+                                           "workflows" :  {"updatedAt" : future_time},
+                                           "owners" :  {"updatedAt" :  future_time},
+                                           "contact_lists" :  {"updatedAt" :  future_time,
+                                                               "offset" :  {}},
+                                           "email_events" :  {"startTimestamp" : future_time,
+                                                              "offset" : {}},
+                                           "companies" :  {"offset" : {},
+                                                           "hs_lastmodifieddate" :  future_time},
+                                           "engagements" :  {"lastUpdated" :  future_time,
+                                                             "offset" : {}}}}
+
+        menagerie.set_state(conn_id, future_bookmarks)
+
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+
+        #verify tap and target exit codes
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+
+        record_count_by_stream = runner.examine_target_output_file(self, conn_id, self.expected_sync_streams(), self.expected_pks())
+
+        #because the bookmarks were set into the future, we should NOT actually replicate any data.
+        #minus campaigns, and deal_pipelines because those endpoints do NOT suppport bookmarks
+        streams_with_bookmarks = self.expected_sync_streams()
+        streams_with_bookmarks.remove('campaigns')
+        streams_with_bookmarks.remove('deal_pipelines')
+        bad_streams = streams_with_bookmarks.intersection(record_count_by_stream.keys())
+        self.assertEqual(len(bad_streams), 0, msg="still pulled down records from {} despite future bookmarks".format(bad_streams))
+
+
+        state = menagerie.get_state(conn_id)
+
+        # NB: Companies and engagements won't set a bookmark in the future.
+        state["bookmarks"].pop("companies")
+        state["bookmarks"].pop("engagements")
+        future_bookmarks["bookmarks"].pop("companies")
+        future_bookmarks["bookmarks"].pop("engagements")
+
+        self.assertEqual(state, future_bookmarks, msg="state should not have been modified because we didn't replicate any data")
+        bookmarks = state.get('bookmarks')
+        bookmark_streams = set(state.get('bookmarks').keys())
+
+
+
+
+SCENARIOS.add(HubSpotBookmarks2)


### PR DESCRIPTION
# Description of change

Moves properties for certain streams (`deals`, `contacts`, `companies`) to the top level so they are selectable and also keep them nested under `properties`.

Moves versions of data to the top level and nests under `properties_versions`

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
