### PR TITLE
use includeAllProperties flag for deals

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -488,9 +488,11 @@ def sync_deals(STATE, ctx):
     # Append all the properties fields for deals to the request if
     # properties is selectedOB
     if mdata.get(('properties', 'properties'), {}).get('selected'):
-        additional_properties = schema.get("properties").get("properties").get("properties")
-        for key in additional_properties.keys():
-            params['properties'].append(key)
+        params['includeAllProperties'] = True
+        params['allPropertiesFetchMode'] = 'latest_version'
+        #additional_properties = schema.get("properties").get("properties").get("properties")
+        #for key in additional_properties.keys():
+        #    params['properties'].append(key)
 
     url = get_url('deals_all')
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -485,14 +485,14 @@ def sync_deals(STATE, ctx):
             if (assoc_mdata.get('selected') and assoc_mdata.get('selected') == True):
                 params['includeAssociations'] = True
 
-    # Append all the properties fields for deals to the request if
-    # properties is selectedOB
     if mdata.get(('properties', 'properties'), {}).get('selected'):
+        # On 2/12/20, hubspot added a lot of additional properties for
+        # deals, and appending all of them to requests ended up leading to
+        # 414 (url-too-long) errors. Hubspot recommended we use the
+        # `includeAllProperties` and `allpropertiesFetchMode` params
+        # instead.
         params['includeAllProperties'] = True
         params['allPropertiesFetchMode'] = 'latest_version'
-        #additional_properties = schema.get("properties").get("properties").get("properties")
-        #for key in additional_properties.keys():
-        #    params['properties'].append(key)
 
     url = get_url('deals_all')
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:


### PR DESCRIPTION
# Description of change
On 2/12/20, Hubspot's API started returning a lot more additional properties for the `deals` stream, and appending all of them to requests led to HTTP 414 (url-too-long) errors. Hubspot recommended using the `includeAllProperties = True` and `allPropertiesFetchMode = 'latest_version'` params in the request instead.

# Manual QA steps
 - Tested on a multiple cloned connections and the 414 error is resolved
 
# Risks
 - Hard to verify that this returns ALL the non-null properties the customer has
 
# Rollback steps
 - revert this branch
