### PR TITLE
Add hs_date_entered/exited fields from v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,8 @@ workflows:
   version: 2
   commit:
     jobs:
-      - build
+      - build:
+          context: circleci-user
   build_daily:
     triggers:
       - schedule:
@@ -55,4 +56,5 @@ workflows:
               only:
                 - master
     jobs:
-      - build
+      - build:
+          context: circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,28 +2,31 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
     steps:
       - checkout
       - run:
           name: 'Setup virtual env'
           command: |
-            virtualenv -p python3 ~/.virtualenvs/tap-hubspot
-            source ~/.virtualenvs/tap-hubspot/bin/activate
-            pip install .
-            pip install pylint
+            python3 -m venv /usr/local/share/virtualenvs/tap-hubspot/
+            source /usr/local/share/virtualenvs/tap-hubspot/bin/activate
+            pip install -U 'pip<19.2' setuptools
+            pip install .[dev]
+      - run:
+          name: 'pylint'
+          command: |
+            source /usr/local/share/virtualenvs/tap-hubspot/bin/activate
             pylint tap_hubspot -d C,R,W
       - run:
           name: 'Unit Tests'
           command: |
-            source ~/.virtualenvs/tap-hubspot/bin/activate
-            pip install nose
+            source /usr/local/share/virtualenvs/tap-hubspot/bin/activate
             nosetests tap_hubspot/tests
       - run:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json ~/.virtualenvs/tap-hubspot/lib/python3.5/site-packages/tap_hubspot/schemas/*.json
+            stitch-validate-json /usr/local/share/virtualenvs/tap-hubspot/lib/python3.5/site-packages/tap_hubspot/schemas/*.json
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,13 @@ setup(name='tap-hubspot',
           'requests==2.20.0',
           'backoff==1.3.2',
           'requests_mock==1.3.0',
-          'nose'
       ],
+      extras_require= {
+          'dev': [
+              'pylint==2.5.3',
+              'nose==1.3.7',
+          ]
+      },
       entry_points='''
           [console_scripts]
           tap-hubspot=tap_hubspot:main

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -72,8 +72,8 @@ ENDPOINTS = {
     "companies_detail":     "/companies/v2/companies/{company_id}",
     "contacts_by_company":  "/companies/v2/companies/{company_id}/vids",
 
-    "deals_properties":     "/properties/v1/deals/properties",
-    "deals_all":            "/deals/v1/deal/paged",
+    "deals_properties":     "/crm/v3/properties/deals",
+    "deals_all":            "/crm/v3/objects/deals",
     "deals_recent":         "/deals/v1/deal/recent/modified",
     "deals_detail":         "/deals/v1/deal/{deal_id}",
 

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -72,8 +72,8 @@ ENDPOINTS = {
     "companies_detail":     "/companies/v2/companies/{company_id}",
     "contacts_by_company":  "/companies/v2/companies/{company_id}/vids",
 
-    "deals_properties":     "/crm/v3/properties/deals",
-    "deals_all":            "/crm/v3/objects/deals",
+    "deals_properties":     "/properties/v1/deals/properties",
+    "deals_all":            "/deals/v1/deal/paged",
     "deals_recent":         "/deals/v1/deal/recent/modified",
     "deals_detail":         "/deals/v1/deal/{deal_id}",
 

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -76,7 +76,8 @@ ENDPOINTS = {
     "deals_all":            "/deals/v1/deal/paged",
     "deals_recent":         "/deals/v1/deal/recent/modified",
     "deals_detail":         "/deals/v1/deal/{deal_id}",
-
+    "deals_v3_search":      "/crm/v3/objects/deals/search",
+    "deals_v3_properties":  "/crm/v3/properties/deals",
     "deal_pipelines":       "/deals/v1/pipelines",
 
     "campaigns_all":        "/email/public/v1/campaigns/by-id",
@@ -158,17 +159,23 @@ def get_field_schema(field_type, extras=False):
                 "value": get_field_type_schema(field_type),
             }
         }
-
-def parse_custom_schema(entity_name, data):
+def parse_custom_schema(entity_name, data, force_extras=None):
+    if force_extras is not None:
+        extras = force_extras
+    else:
+        extras = entity_name != 'contacts'
     return {
-        field['name']: get_field_schema(
-            field['type'], entity_name != "contacts")
+        field['name']: get_field_schema(field['type'], extras)
         for field in data
     }
 
 
 def get_custom_schema(entity_name):
     return parse_custom_schema(entity_name, request(get_url(entity_name + "_properties")).json())
+
+def get_v3_schema(entity_name):
+    url = get_url("deals_v3_properties")
+    return parse_custom_schema(entity_name, request(url).json()['results'], force_extras=False)
 
 
 def get_abs_path(path):
@@ -190,6 +197,12 @@ def load_schema(entity_name):
             "type": "object",
             "properties": custom_schema,
         }
+
+        if entity_name in ["deals"]:
+            v3_schema = get_v3_schema(entity_name)
+            for key, value in v3_schema.items():
+                if 'hs_date_entered' in key or 'hs_date_exited' in key:
+                    custom_schema[key] = value
 
         # Move properties to top level
         custom_schema_top_level = {'property_{}'.format(k): v for k, v in custom_schema.items()}
@@ -307,8 +320,37 @@ def lift_properties_and_versions(record):
             record['properties_versions'] += versions
     return record
 
+def post_search_endpoint(url, data, params=None):
+    params = params or {}
+    hapikey = CONFIG['hapikey']
+    if hapikey is None:
+        if CONFIG['token_expires'] is None or CONFIG['token_expires'] < datetime.datetime.utcnow():
+            acquire_access_token_from_refresh_token()
+        headers = {'Authorization': 'Bearer {}'.format(CONFIG['access_token'])}
+    else:
+        params['hapikey'] = hapikey
+        headers = {}
+
+    if 'user_agent' in CONFIG:
+        headers['User-Agent'] = CONFIG['user_agent']
+
+    headers['content-type'] = "application/json"
+
+    # TODO: fix log message
+    with metrics.http_request_timer(url) as timer:
+        resp = requests.post(
+            url=url,
+            json=data,
+            params=params,
+            headers=headers
+        )
+
+        resp.raise_for_status()
+
+    return resp
+
 #pylint: disable=line-too-long
-def gen_request(STATE, tap_stream_id, url, params, path, more_key, offset_keys, offset_targets):
+def gen_request(STATE, tap_stream_id, url, params, path, more_key, offset_keys, offset_targets, v3_fields=None):
     if len(offset_keys) != len(offset_targets):
         raise ValueError("Number of offset_keys must match number of offset_targets")
 
@@ -318,6 +360,19 @@ def gen_request(STATE, tap_stream_id, url, params, path, more_key, offset_keys, 
     with metrics.record_counter(tap_stream_id) as counter:
         while True:
             data = request(url, params).json()
+
+            if v3_fields:
+                url = get_url('deals_v3_search')
+                body = {"properties": v3_fields, "limit": 100}
+                v3_data = post_search_endpoint(url, body)
+                additional_fields = {}
+                for item in v3_data.json()['results']:
+                    # We nest `y` under 'value' in order to match the
+                    # schema and the shape of other fields in 'properties'
+                    additional_fields[int(item['id'])] = {x:{'value': y} for x,y in item['properties'].items()
+                                                          if ('hs_date_entered' in x or 'hs_date_exited' in x)}
+                for item in data[path]:
+                    item['properties'] = {**item['properties'], **additional_fields.get(item['dealId'])}
 
             for row in data[path]:
                 counter.increment()
@@ -513,7 +568,8 @@ def sync_deals(STATE, ctx):
             if (assoc_mdata.get('selected') and assoc_mdata.get('selected') == True):
                 params['includeAssociations'] = True
 
-    if mdata.get(('properties', 'properties'), {}).get('selected') or has_selected_custom_field(mdata):
+    has_selected_properties = mdata.get(('properties', 'properties'), {}).get('selected')
+    if properties_selected or has_selected_custom_field(mdata):
         # On 2/12/20, hubspot added a lot of additional properties for
         # deals, and appending all of them to requests ended up leading to
         # 414 (url-too-long) errors. Hubspot recommended we use the
@@ -522,9 +578,14 @@ def sync_deals(STATE, ctx):
         params['includeAllProperties'] = True
         params['allPropertiesFetchMode'] = 'latest_version'
 
+        # Grab selected `hs_date_entered/exited` fields to call the v3 endpoint with
+        v3_fields = [x[1].replace('property_', '')
+                     for x,y in mdata.items() if x and (y.get('selected') == True or has_selected_properties)
+                     and ('hs_date_entered' in x[1] or 'hs_date_exited' in x[1])]
+
     url = get_url('deals_all')
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
-        for row in gen_request(STATE, 'deals', url, params, 'deals', "hasMore", ["offset"], ["offset"]):
+        for row in gen_request(STATE, 'deals', url, params, 'deals', "hasMore", ["offset"], ["offset"], v3_fields=v3_fields):
             row_properties = row['properties']
             modified_time = None
             if bookmark_key in row_properties:

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -336,7 +336,6 @@ def post_search_endpoint(url, data, params=None):
 
     headers['content-type'] = "application/json"
 
-    # TODO: fix log message
     with metrics.http_request_timer(url) as timer:
         resp = requests.post(
             url=url,
@@ -369,8 +368,8 @@ def gen_request(STATE, tap_stream_id, url, params, path, more_key, offset_keys, 
                 for item in v3_data.json()['results']:
                     # We nest `y` under 'value' in order to match the
                     # schema and the shape of other fields in 'properties'
-                    additional_fields[int(item['id'])] = {x:{'value': y} for x,y in item['properties'].items()
-                                                          if ('hs_date_entered' in x or 'hs_date_exited' in x)}
+                    additional_fields[int(item['id'])] = {key:{'value': value} for key,value in item['properties'].items()
+                                                          if ('hs_date_entered' in key or 'hs_date_exited' in key)}
                 for item in data[path]:
                     item['properties'] = {**item['properties'], **additional_fields.get(item['dealId'])}
 

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -568,8 +568,9 @@ def sync_deals(STATE, ctx):
             if (assoc_mdata.get('selected') and assoc_mdata.get('selected') == True):
                 params['includeAssociations'] = True
 
+    v3_fields = None
     has_selected_properties = mdata.get(('properties', 'properties'), {}).get('selected')
-    if properties_selected or has_selected_custom_field(mdata):
+    if has_selected_properties or has_selected_custom_field(mdata):
         # On 2/12/20, hubspot added a lot of additional properties for
         # deals, and appending all of them to requests ended up leading to
         # 414 (url-too-long) errors. Hubspot recommended we use the

--- a/tap_hubspot/tests/test_deals.py
+++ b/tap_hubspot/tests/test_deals.py
@@ -23,7 +23,7 @@ class TestDealsToSync(unittest.TestCase):
 
         expected_param = {'count': 250, 'includeAssociations': False, 'properties': []}
 
-        mocked_gen_request.assert_called_once_with(ANY, ANY, ANY, expected_param, ANY, ANY, ANY, ANY)
+        mocked_gen_request.assert_called_once_with(ANY, ANY, ANY, expected_param, ANY, ANY, ANY, ANY, v3_fields=ANY)
 
 
     @patch('tap_hubspot.Context.get_catalog_from_id', return_value={"metadata":""})
@@ -44,4 +44,4 @@ class TestDealsToSync(unittest.TestCase):
 
         expected_param = {'count': 250, 'includeAssociations': True, 'properties': []}
 
-        mocked_gen_request.assert_called_once_with(ANY, ANY, ANY, expected_param, ANY, ANY, ANY, ANY)
+        mocked_gen_request.assert_called_once_with(ANY, ANY, ANY, expected_param, ANY, ANY, ANY, ANY, v3_fields=ANY)

--- a/tests/test_hubspot_bookmarks1.py
+++ b/tests/test_hubspot_bookmarks1.py
@@ -156,7 +156,7 @@ class HubSpotBookmarks1(unittest.TestCase):
 
 
     def get_properties(self):
-        return {'start_date' : '2017-05-01 00:00:00'}
+        return {'start_date' : '2017-05-01T00:00:00Z'}
 
     def perform_field_selection(self, conn_id, catalog):
         schema = menagerie.select_catalog(conn_id, catalog)

--- a/tests/test_hubspot_bookmarks2.py
+++ b/tests/test_hubspot_bookmarks2.py
@@ -104,7 +104,7 @@ class HubSpotBookmarks2(unittest.TestCase):
 
 
     def get_properties(self):
-        return {'start_date' : '2017-05-01 00:00:00'}
+        return {'start_date' : '2017-05-01T00:00:00Z'}
 
     def perform_field_selection(self, conn_id, catalog):
         schema = menagerie.select_catalog(conn_id, catalog)


### PR DESCRIPTION
# Description of change
The v3 CRM Deals API has `hs_date_entered_*` and `hs_date_exited_*` fields that the v1 Deals API does not have. This PR discovers and syncs those fields.

# Manual QA steps
 - Ran the tap
 
# Risks
 - Low because everything is an addition
 
# Rollback steps
 - revert this branch
