### PR TITLE
Add `hs_date_entered_*` and `hs_date_exited_*` fields for Deals

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -365,7 +365,7 @@ def process_v3_deals_records(v3_data):
     return transformed_v3_data
 
 def get_v3_deals(v3_fields, v1_data):
-    v1_ids = [{'id': str(record['dealId'])} for record in data[path]]
+    v1_ids = [{'id': str(record['dealId'])} for record in v1_data]
     v3_body = {'inputs': v1_ids,
                'properties': v3_fields,}
     v3_url = get_url('deals_v3_batch_read')

--- a/tests/unittests/test_deals.py
+++ b/tests/unittests/test_deals.py
@@ -36,14 +36,15 @@ class TestDeals(unittest.TestCase):
         params = {'count': 250,
                   'includeAssociations': False,
                   'properties' : []}
+        v3_fields = ['hs_date_entered_appointmentscheduled']
 
         records = list(
-            gen_request(state, 'deals', url, params, 'deals', "hasMore", ["offset"], ["offset"])
+            gen_request(state, 'deals', url, params, 'deals', "hasMore", ["offset"], ["offset"], v3_fields=v3_fields)
         )
 
         for record in records:
             # The test account has a deal stage called "appointment scheduled"
-            value = record.get('properties',{}).get('hs_date_entered_appointment_scheduled')
+            value = record.get('properties',{}).get('hs_date_entered_appointmentscheduled')
             error_msg = ('Could not find "hs_date_entered_appointment_scheduled"'
                          'in {}').format(record)
             self.assertIsNotNone(value, msg=error_msg)

--- a/tests/unittests/test_deals.py
+++ b/tests/unittests/test_deals.py
@@ -7,6 +7,7 @@ from tap_hubspot import acquire_access_token_from_refresh_token
 from tap_hubspot import CONFIG
 from tap_hubspot import gen_request
 from tap_hubspot import get_url
+from tap_hubspot import process_v3_deals_records
 
 
 class TestDeals(unittest.TestCase):
@@ -48,3 +49,21 @@ class TestDeals(unittest.TestCase):
             error_msg = ('Could not find "hs_date_entered_appointment_scheduled"'
                          'in {}').format(record)
             self.assertIsNotNone(value, msg=error_msg)
+
+    def test_process_v3_deals_records(self):
+        self.maxDiff = None
+        data = [
+            {'properties': {'field1': 'value1',
+                            'field2': 'value2',
+                            'hs_date_entered_field3': 'value3',
+                            'hs_date_exited_field4': 'value4',}},
+        ]
+
+        expected = [
+            {'properties': {'hs_date_entered_field3': {'value': 'value3'},
+                            'hs_date_exited_field4':  {'value': 'value4'},}},
+        ]
+
+        actual = process_v3_deals_records(data)
+
+        self.assertDictEqual(expected[0]['properties'], actual[0]['properties'])

--- a/tests/unittests/test_deals.py
+++ b/tests/unittests/test_deals.py
@@ -7,6 +7,7 @@ from tap_hubspot import acquire_access_token_from_refresh_token
 from tap_hubspot import CONFIG
 from tap_hubspot import gen_request
 from tap_hubspot import get_url
+from tap_hubspot import merge_responses
 from tap_hubspot import process_v3_deals_records
 
 
@@ -67,3 +68,34 @@ class TestDeals(unittest.TestCase):
         actual = process_v3_deals_records(data)
 
         self.assertDictEqual(expected[0]['properties'], actual[0]['properties'])
+
+    def test_merge_responses(self):
+        v1_resp = [
+            {'dealId': '1',
+             'properties': {'field1': 'value1',}},
+            {'dealId': '2',
+             'properties': {'field3': 'value3',}},
+        ]
+
+        v3_resp = [
+            {'id': '1',
+             'properties': {'field2': 'value2',}},
+            {'id': '2',
+             'properties': {'field4': 'value4',}},
+        ]
+
+        expected = [
+            {'dealId': '1',
+             'properties': {'field1': 'value1',
+                            'field2': 'value2',}},
+            {'dealId': '2',
+             'properties': {'field3': 'value3',
+                            'field4': 'value4',}},
+        ]
+
+        merge_responses(v1_resp, v3_resp)
+
+        for expected_record in expected:
+            for actual_record in v1_resp:
+                if actual_record['dealId'] == expected_record['dealId']:
+                    self.assertDictEqual(expected_record, actual_record)

--- a/tests/unittests/test_deals.py
+++ b/tests/unittests/test_deals.py
@@ -1,0 +1,49 @@
+"""
+Unit tests at the functions need to run `sync_deals`
+"""
+import os
+import unittest
+from tap_hubspot import acquire_access_token_from_refresh_token
+from tap_hubspot import CONFIG
+from tap_hubspot import gen_request
+from tap_hubspot import get_url
+
+
+class TestDeals(unittest.TestCase):
+    """
+    This class gets an access token for the tests to use and then tests
+    assumptions we have about the tap
+    """
+    def setUp(self):
+        """
+        This functions reads in the variables need to get an access token
+        """
+        CONFIG['redirect_uri'] = os.environ['HUBSPOT_REDIRECT_URI']
+        CONFIG['refresh_token'] = os.environ['HUBSPOT_REFRESH_TOKEN']
+        CONFIG['client_id'] = os.environ['HUBSPOT_CLIENT_ID']
+        CONFIG['client_secret'] = os.environ['HUBSPOT_CLIENT_SECRET']
+
+        acquire_access_token_from_refresh_token()
+
+
+    def test_can_fetch_hs_date_entered_props(self):
+        """
+        This test is written on the assumption that `sync_deals()` calls
+        `gen_request()` to get records
+        """
+        state = {}
+        url = get_url('deals_all')
+        params = {'count': 250,
+                  'includeAssociations': False,
+                  'properties' : []}
+
+        records = list(
+            gen_request(state, 'deals', url, params, 'deals', "hasMore", ["offset"], ["offset"])
+        )
+
+        for record in records:
+            # The test account has a deal stage called "appointment scheduled"
+            value = record.get('properties',{}).get('hs_date_entered_appointment_scheduled')
+            error_msg = ('Could not find "hs_date_entered_appointment_scheduled"'
+                         'in {}').format(record)
+            self.assertIsNotNone(value, msg=error_msg)


### PR DESCRIPTION
# Description of change
This PR hits the V3 Deals CRM API to get all `hs_date_entered_*` and `hs_date_exited_*` fields.

The "batch read" endpoint that Hubspot has lets us search for specific IDs. Given that V1 Deals and V3 Deals have the same primary key (`"dealId"` and `"id"` respectively) values, we can merge these new fields into the existing records

# Manual QA steps
- Ran the tap before and after the change to get records
- Diffed the two sets of records
 
# Risks
- Lower than #124. The main issue there is we did not paginate the V3 response and could not prove whether the first page of V1 records contains the same IDs as the first page of V3 records. But now that we are searching the V3 for explicit IDs we don't have to worry about that
 
# Rollback steps
 - revert this branch and bump the version
