### PR TITLE
Add `hs_date_entered_*` and `hs_date_exited_*` fields for the Deals Stream

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -372,7 +372,7 @@ def get_v3_deals(v3_fields, v1_data):
     return v3_resp.json()['results']
 
 #pylint: disable=line-too-long
-def gen_request(STATE, tap_stream_id, url, params, path, more_key, offset_keys, offset_targets):
+def gen_request(STATE, tap_stream_id, url, params, path, more_key, offset_keys, offset_targets, v3_fields=None):
     if len(offset_keys) != len(offset_targets):
         raise ValueError("Number of offset_keys must match number of offset_targets")
 

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -571,8 +571,7 @@ def sync_deals(STATE, ctx):
     max_bk_value = start
     LOGGER.info("sync_deals from %s", start)
     most_recent_modified_time = start
-    params = {'count': 250,
-              'limit': 100,
+    params = {'limit': 100,
               'includeAssociations': False,
               'properties' : []}
 

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -162,13 +162,10 @@ def get_field_schema(field_type, extras=False):
             }
         }
 
-def parse_custom_schema(entity_name, data, force_extras=None):
-    if force_extras is not None:
-        extras = force_extras
-    else:
-        extras = entity_name != 'contacts'
+def parse_custom_schema(entity_name, data):
+
     return {
-        field['name']: get_field_schema(field['type'], extras)
+        field['name']: get_field_schema(field['type'], entity_name != 'contacts')
         for field in data
     }
 
@@ -178,7 +175,7 @@ def get_custom_schema(entity_name):
 
 def get_v3_schema(entity_name):
     url = get_url("deals_v3_properties")
-    return parse_custom_schema(entity_name, request(url).json()['results'], force_extras=False)
+    return parse_custom_schema(entity_name, request(url).json()['results'])
 
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -607,9 +607,11 @@ def sync_deals(STATE, ctx):
         params['allPropertiesFetchMode'] = 'latest_version'
 
         # Grab selected `hs_date_entered/exited` fields to call the v3 endpoint with
-        v3_fields = [x[1].replace('property_', '')
-                     for x,y in mdata.items() if x and (y.get('selected') == True or has_selected_properties)
-                     and ('hs_date_entered' in x[1] or 'hs_date_exited' in x[1] or 'hs_time_in' in x[1])]
+        v3_fields = [breadcrumb[1].replace('property_', '')
+                     for breadcrumb, mdata_map in mdata.items()
+                     if breadcrumb
+                     and (mdata_map.get('selected') == True or has_selected_properties)
+                     and any(prefix in breadcrumb[1] for prefix in V3_PREFIXES)]
 
     url = get_url('deals_all')
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -162,10 +162,13 @@ def get_field_schema(field_type, extras=False):
             }
         }
 
-def parse_custom_schema(entity_name, data):
+def parse_custom_schema(entity_name, data, force_extras=None):
+    if force_extras is not None:
+        extras = force_extras
+    else:
+        extras = entity_name != 'contacts'
     return {
-        field['name']: get_field_schema(
-            field['type'], entity_name != "contacts")
+        field['name']: get_field_schema(field['type'], extras)
         for field in data
     }
 

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -44,6 +44,8 @@ CONTACTS_BY_COMPANY = "contacts_by_company"
 
 DEFAULT_CHUNK_SIZE = 1000 * 60 * 60 * 24
 
+V3_PREFIXES = {'hs_date_entered', 'hs_date_exited', 'hs_time_in'}
+
 CONFIG = {
     "access_token": None,
     "token_expires": None,
@@ -200,7 +202,7 @@ def load_schema(entity_name):
         if entity_name in ["deals"]:
             v3_schema = get_v3_schema(entity_name)
             for key, value in v3_schema.items():
-                if 'hs_date_entered' in key or 'hs_date_exited' in key or 'hs_time_in' in key:
+                if any(prefix in key for prefix in V3_PREFIXES):
                     custom_schema[key] = value
 
         # Move properties to top level
@@ -368,7 +370,7 @@ def process_v3_deals_records(v3_data):
     for record in v3_data:
         new_properties = {field_name : {'value': field_value}
                           for field_name, field_value in record['properties'].items()
-                          if 'hs_date_entered' in field_name or 'hs_date_exited' in field_name or 'hs_time_in' in field_name}
+                          if any(prefix in field_name for prefix in V3_PREFIXES)}
         transformed_v3_data.append({**record, 'properties' : new_properties})
     return transformed_v3_data
 

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -374,7 +374,7 @@ def process_v3_deals_records(v3_data):
     return transformed_v3_data
 
 def get_v3_deals(v3_fields, v1_data):
-    v1_ids = [{'id': str(record['dealId'])} for record in data[path]]
+    v1_ids = [{'id': str(record['dealId'])} for record in v1_data]
     v3_body = {'inputs': v1_ids,
                'properties': v3_fields,}
     v3_url = get_url('deals_v3_batch_read')

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -203,7 +203,7 @@ def load_schema(entity_name):
         if entity_name in ["deals"]:
             v3_schema = get_v3_schema(entity_name)
             for key, value in v3_schema.items():
-                if 'hs_date_entered' in key or 'hs_date_exited' in key:
+                if 'hs_date_entered' in key or 'hs_date_exited' in key or 'hs_time_in' in key:
                     custom_schema[key] = value
 
         # Move properties to top level
@@ -371,12 +371,13 @@ def process_v3_deals_records(v3_data):
     for record in v3_data:
         new_properties = {field_name : {'value': field_value}
                           for field_name, field_value in record['properties'].items()
-                          if 'hs_date_entered' in field_name or 'hs_date_exited' in field_name}
+                          if 'hs_date_entered' in field_name or 'hs_date_exited' in field_name or 'hs_time_in' in field_name}
         transformed_v3_data.append({**record, 'properties' : new_properties})
     return transformed_v3_data
 
 def get_v3_deals(v3_fields, v1_data):
     v1_ids = [{'id': str(record['dealId'])} for record in v1_data]
+
     v3_body = {'inputs': v1_ids,
                'properties': v3_fields,}
     v3_url = get_url('deals_v3_batch_read')
@@ -611,7 +612,7 @@ def sync_deals(STATE, ctx):
         # Grab selected `hs_date_entered/exited` fields to call the v3 endpoint with
         v3_fields = [x[1].replace('property_', '')
                      for x,y in mdata.items() if x and (y.get('selected') == True or has_selected_properties)
-                     and ('hs_date_entered' in x[1] or 'hs_date_exited' in x[1])]
+                     and ('hs_date_entered' in x[1] or 'hs_date_exited' in x[1] or 'hs_time_in' in x[1])]
 
     url = get_url('deals_all')
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -394,6 +394,9 @@ def gen_request(STATE, tap_stream_id, url, params, path, more_key, offset_keys, 
         while True:
             data = request(url, params).json()
 
+            if data.get(path) is None:
+                raise RuntimeError("Unexpected API response: {} not in {}".format(path, data.keys()))
+
             if v3_fields:
                 v3_data = get_v3_deals(v3_fields, data[path])
 
@@ -498,6 +501,10 @@ def _sync_contacts_by_company(STATE, ctx, company_id):
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
         with metrics.record_counter(CONTACTS_BY_COMPANY) as counter:
             data = request(url, default_contacts_by_company_params).json()
+
+            if data.get(path) is None:
+                raise RuntimeError("Unexpected API response: {} not in {}".format(path, data.keys()))
+
             for row in data[path]:
                 counter.increment()
                 record = {'company-id' : company_id,
@@ -695,6 +702,9 @@ def sync_entity_chunked(STATE, catalog, entity_name, key_properties, path):
 
                     data = request(url, params).json()
                     time_extracted = utils.now()
+
+                    if data.get(path) is None:
+                        raise RuntimeError("Unexpected API response: {} not in {}".format(path, data.keys()))
 
                     for row in data[path]:
                         counter.increment()

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -1013,7 +1013,7 @@ def load_discovered_schema(stream):
         mdata = metadata.write(mdata, (), 'valid-replication-keys', [stream.replication_key])
 
     for field_name, props in schema['properties'].items():
-        if field_name in stream.key_properties or (stream.replication_key and stream.replication_key in field_name):
+        if field_name in stream.key_properties or field_name == stream.replication_key:
             mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
         else:
             mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'available')
@@ -1021,6 +1021,7 @@ def load_discovered_schema(stream):
     # The engagements stream has nested data that we synthesize; The engagement field needs to be automatic
     if stream.tap_stream_id == "engagements":
         mdata = metadata.write(mdata, ('properties', 'engagement'), 'inclusion', 'automatic')
+        mdata = metadata.write(mdata, ('properties', 'lastUpdated'), 'inclusion', 'automatic')
 
     return schema, metadata.to_list(mdata)
 

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -173,6 +173,9 @@ def parse_custom_schema(entity_name, data):
 def get_custom_schema(entity_name):
     return parse_custom_schema(entity_name, request(get_url(entity_name + "_properties")).json())
 
+def get_v3_schema(entity_name):
+    url = get_url("deals_v3_properties")
+    return parse_custom_schema(entity_name, request(url).json()['results'], force_extras=False)
 
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
@@ -193,6 +196,12 @@ def load_schema(entity_name):
             "type": "object",
             "properties": custom_schema,
         }
+
+        if entity_name in ["deals"]:
+            v3_schema = get_v3_schema(entity_name)
+            for key, value in v3_schema.items():
+                if 'hs_date_entered' in key or 'hs_date_exited' in key:
+                    custom_schema[key] = value
 
         # Move properties to top level
         custom_schema_top_level = {'property_{}'.format(k): v for k, v in custom_schema.items()}

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -1006,7 +1006,7 @@ def load_discovered_schema(stream):
         mdata = metadata.write(mdata, (), 'valid-replication-keys', [stream.replication_key])
 
     for field_name, props in schema['properties'].items():
-        if field_name in stream.key_properties or field_name == stream.replication_key:
+        if field_name in stream.key_properties or (stream.replication_key and stream.replication_key in field_name):
             mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
         else:
             mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'available')

--- a/tap_hubspot/schemas/engagements.json
+++ b/tap_hubspot/schemas/engagements.json
@@ -4,6 +4,10 @@
     "engagement_id": {
       "type": "integer"
     },
+    "lastUpdated": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
     "engagement": {
       "type": "object",
       "properties": {

--- a/tap_hubspot/tests/test_deals.py
+++ b/tap_hubspot/tests/test_deals.py
@@ -21,7 +21,7 @@ class TestDealsToSync(unittest.TestCase):
 
         sync_deals({}, mocked_catalog_from_id)
 
-        expected_param = {'count': 250, 'includeAssociations': False, 'properties': [], 'limit': 100}
+        expected_param = {'includeAssociations': False, 'properties': [], 'limit': 100}
 
         mocked_gen_request.assert_called_once_with(ANY, ANY, ANY, expected_param, ANY, ANY, ANY, ANY, v3_fields=None)
 
@@ -42,6 +42,6 @@ class TestDealsToSync(unittest.TestCase):
 
         sync_deals({}, mocked_catalog_from_id)
 
-        expected_param = {'count': 250, 'includeAssociations': True, 'properties': [], 'limit': 100}
+        expected_param = {'includeAssociations': True, 'properties': [], 'limit': 100}
 
         mocked_gen_request.assert_called_once_with(ANY, ANY, ANY, expected_param, ANY, ANY, ANY, ANY, v3_fields=None)

--- a/tap_hubspot/tests/test_deals.py
+++ b/tap_hubspot/tests/test_deals.py
@@ -21,7 +21,7 @@ class TestDealsToSync(unittest.TestCase):
 
         sync_deals({}, mocked_catalog_from_id)
 
-        expected_param = {'count': 250, 'includeAssociations': False, 'properties': []}
+        expected_param = {'count': 250, 'includeAssociations': False, 'properties': [], 'limit': 100}
 
         mocked_gen_request.assert_called_once_with(ANY, ANY, ANY, expected_param, ANY, ANY, ANY, ANY)
 
@@ -42,6 +42,6 @@ class TestDealsToSync(unittest.TestCase):
 
         sync_deals({}, mocked_catalog_from_id)
 
-        expected_param = {'count': 250, 'includeAssociations': True, 'properties': []}
+        expected_param = {'count': 250, 'includeAssociations': True, 'properties': [], 'limit': 100}
 
         mocked_gen_request.assert_called_once_with(ANY, ANY, ANY, expected_param, ANY, ANY, ANY, ANY)

--- a/tap_hubspot/tests/test_deals.py
+++ b/tap_hubspot/tests/test_deals.py
@@ -23,7 +23,7 @@ class TestDealsToSync(unittest.TestCase):
 
         expected_param = {'count': 250, 'includeAssociations': False, 'properties': [], 'limit': 100}
 
-        mocked_gen_request.assert_called_once_with(ANY, ANY, ANY, expected_param, ANY, ANY, ANY, ANY)
+        mocked_gen_request.assert_called_once_with(ANY, ANY, ANY, expected_param, ANY, ANY, ANY, ANY, v3_fields=None)
 
 
     @patch('tap_hubspot.Context.get_catalog_from_id', return_value={"metadata":""})
@@ -44,4 +44,4 @@ class TestDealsToSync(unittest.TestCase):
 
         expected_param = {'count': 250, 'includeAssociations': True, 'properties': [], 'limit': 100}
 
-        mocked_gen_request.assert_called_once_with(ANY, ANY, ANY, expected_param, ANY, ANY, ANY, ANY)
+        mocked_gen_request.assert_called_once_with(ANY, ANY, ANY, expected_param, ANY, ANY, ANY, ANY, v3_fields=None)

--- a/tests/base.py
+++ b/tests/base.py
@@ -313,10 +313,8 @@ class HubspotBaseTest(unittest.TestCase):
         selected_fields = set()
         for field in metadata:
             is_field_metadata = len(field['breadcrumb']) > 1
-            inclusion_automatic_or_selected = (
-                field['metadata']['selected'] is True or \
-                field['metadata']['inclusion'] == 'automatic'
-            )
+            inclusion_automatic_or_selected = (field['metadata'].get('inclusion') == 'automatic'
+                                               or field['metadata'].get('selected') is True)
             if is_field_metadata and inclusion_automatic_or_selected:
                 selected_fields.add(field['breadcrumb'][1])
         return selected_fields

--- a/tests/base.py
+++ b/tests/base.py
@@ -49,6 +49,22 @@ class HubspotBaseTest(unittest.TestCase):
                 'redirect_uri':  os.getenv('TAP_HUBSPOT_REDIRECT_URI'),
                 'client_id':     os.getenv('TAP_HUBSPOT_CLIENT_ID')}
 
+    def expected_check_streams(self):
+        return {
+            "subscription_changes",
+            "email_events",
+            "forms",
+            "workflows",
+            "owners",
+            "campaigns",
+            "contact_lists",
+            "contacts",
+            "companies",
+            "deals",
+            "engagements",
+            "deal_pipelines",
+            "contacts_by_company"
+        }
 
     def expected_metadata(self):  # DOCS_BUG https://stitchdata.atlassian.net/browse/DOC-1523)
         """The expected streams and metadata about the streams"""

--- a/tests/base.py
+++ b/tests/base.py
@@ -233,8 +233,8 @@ class HubspotBaseTest(unittest.TestCase):
         self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
 
         found_catalog_names = set(map(lambda c: c['tap_stream_id'], found_catalogs))
-        diff = self.expected_streams().symmetric_difference(found_catalog_names)
-        self.assertEqual(len(diff), 0, msg="discovered schemas do not match: {}".format(diff))
+        self.assertSetEqual(self.expected_streams(), found_catalog_names,
+                            msg="discovered schemas do not match")
         print("discovered schemas are OK")
 
         return found_catalogs
@@ -253,13 +253,14 @@ class HubspotBaseTest(unittest.TestCase):
         menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
 
         # Verify actual rows were synced
-        sync_record_count = runner.examine_target_output_file(
-            self, conn_id, self.expected_streams(), self.expected_primary_keys())
-        self.assertGreater(
-            sum(sync_record_count.values()), 0,
-            msg="failed to replicate any data: {}".format(sync_record_count)
-        )
-        print("total replicated row count: {}".format(sum(sync_record_count.values())))
+        sync_record_count = runner.examine_target_output_file(self,
+                                                              conn_id,
+                                                              self.expected_streams(),
+                                                              self.expected_primary_keys())
+        total_row_count = sum(sync_record_count.values())
+        self.assertGreater(total_row_count, 0,
+                           msg="failed to replicate any data: {}".format(sync_record_count))
+        print("total replicated row count: {}".format(total_row_count))
 
         return sync_record_count
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -336,6 +336,14 @@ class HubspotBaseTest(unittest.TestCase):
             connections.select_catalog_and_fields_via_metadata(
                 conn_id, catalog, schema, [], non_selected_properties)
 
+    def perform_field_selection(self, conn_id, catalog):
+        schema = menagerie.select_catalog(conn_id, catalog)
+
+        return {'key_properties' :     catalog.get('key_properties'),
+                'schema' :             schema,
+                'tap_stream_id':       catalog.get('tap_stream_id'),
+                'replication_method' : catalog.get('replication_method'),
+                'replication_key'    : catalog.get('replication_key')}
 
     ################################
     #  Tap Specific Test Actions   #

--- a/tests/base.py
+++ b/tests/base.py
@@ -59,20 +59,18 @@ class HubspotBaseTest(unittest.TestCase):
             },
             "companies": {
                 self.PRIMARY_KEYS: {"companyId"},
-                self.REPLICATION_METHOD: self.FULL,
-                self.REPLICATION_KEYS: set(),
-                # self.REPLICATION_KEYS: {"hs_lastmodifieddate"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"hs_lastmodifieddate"},
             },
             "contact_lists": {
                 self.PRIMARY_KEYS: {"listId"},
-                self.REPLICATION_METHOD: self.FULL,
+                self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"updatedAt"},
             },
             "contacts": {
                 self.PRIMARY_KEYS: {"vid"},  # DOCS_BUG listed in stitch docs as 'canonical-vid'
-                self.REPLICATION_METHOD: self.FULL,
-                self.REPLICATION_KEYS: set(), # it doesn't appear in the catalog
-                # self.REPLICATION_KEYS: {"versionTimestamp"},  # DOCS_BUG  was commented out in OG tests
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"versionTimestamp"},  # DOCS_BUG  was commented out in OG tests
             },
             "contacts_by_company": {
                 self.PRIMARY_KEYS: {"company-id", "contact-id"},
@@ -84,46 +82,37 @@ class HubspotBaseTest(unittest.TestCase):
             },
             "deals": {
                 self.PRIMARY_KEYS: {"dealId"},  # DOCS_BUG docs list 'dealId' and 'portalId
-                self.REPLICATION_METHOD: self.FULL,
-                self.REPLICATION_KEYS: set(),
-                # Technically this is true, but `hs_lastmodifieddate` is a
-                # field on the `properties` object, and we don't select
-                # that, so it doesn't get lifted and the resulting record
-                # is missing this key
-                # self.REPLICATION_KEYS: {"property_hs_lastmodifieddate"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"hs_lastmodifieddate"},
             },
             "email_events": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                # self.REPLICATION_KEYS: {'startTimestamp'},
-                self.REPLICATION_KEYS: set(),
-                # self.REPLICATION_KEYS: {"property_startTimestamp"},  # DOCS_BUG docs list 'id' but OG tests use
+                self.REPLICATION_KEYS: {"startTimestamp"},  # DOCS_BUG docs list 'id' but OG tests use
             },
             "engagements": {
                 self.PRIMARY_KEYS: {"engagement_id"},  # DOCS_BUG docs list 'id'
-                self.REPLICATION_METHOD: self.FULL,
-                self.REPLICATION_KEYS: {"engagement", "lastUpdated"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"lastUpdated"},
             },
             "forms": {
                 self.PRIMARY_KEYS: {"guid"},
-                self.REPLICATION_METHOD: self.FULL,
+                self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"updatedAt"},
             },
             "owners": {
                 self.PRIMARY_KEYS: {"ownerId"},  # DOCS_BUG docs list 'portalId'
-                self.REPLICATION_METHOD: self.FULL,
+                self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"updatedAt"},
             },
             "subscription_changes": {
                 self.PRIMARY_KEYS: {"timestamp", "portalId", "recipient"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                # self.REPLICATION_KEYS: {'startTimestamp'},
-                self.REPLICATION_KEYS: set(),
-                # self.REPLICATION_KEYS: {"property_startTimestamp"},  # DOCS_BUG docs list 'timestamp'
+                self.REPLICATION_KEYS: {"startTimestamp"},  # DOCS_BUG docs list 'timestamp'
             },
             "workflows": {
                 self.PRIMARY_KEYS: {"id"},
-                self.REPLICATION_METHOD: self.FULL,
+                self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"updatedAt"},
             }
         }

--- a/tests/base.py
+++ b/tests/base.py
@@ -60,7 +60,8 @@ class HubspotBaseTest(unittest.TestCase):
             "companies": {
                 self.PRIMARY_KEYS: {"companyId"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"property_hs_lastmodifieddate"},
+                self.REPLICATION_KEYS: set(),
+                # self.REPLICATION_KEYS: {"hs_lastmodifieddate"},
             },
             "contact_lists": {
                 self.PRIMARY_KEYS: {"listId"},
@@ -84,7 +85,12 @@ class HubspotBaseTest(unittest.TestCase):
             "deals": {
                 self.PRIMARY_KEYS: {"dealId"},  # DOCS_BUG docs list 'dealId' and 'portalId
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"property_hs_lastmodifieddate"},
+                self.REPLICATION_KEYS: set(),
+                # Technically this is true, but `hs_lastmodifieddate` is a
+                # field on the `properties` object, and we don't select
+                # that, so it doesn't get lifted and the resulting record
+                # is missing this key
+                # self.REPLICATION_KEYS: {"property_hs_lastmodifieddate"},
             },
             "email_events": {
                 self.PRIMARY_KEYS: {"id"},
@@ -95,7 +101,7 @@ class HubspotBaseTest(unittest.TestCase):
             "engagements": {
                 self.PRIMARY_KEYS: {"engagement_id"},  # DOCS_BUG docs list 'id'
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"engagement", 'lastUpdated'},
+                self.REPLICATION_KEYS: {"engagement", "lastUpdated"},
             },
             "forms": {
                 self.PRIMARY_KEYS: {"guid"},

--- a/tests/base.py
+++ b/tests/base.py
@@ -211,10 +211,6 @@ class HubspotBaseTest(unittest.TestCase):
         menagerie.verify_check_exit_status(self, exit_status, check_job_name)
         return conn_id
 
-    def ensure_connection(self, original=True):
-        conn_id = connections.ensure_connection(self, original_properties = original)
-        return conn_id
-
     def run_and_verify_check_mode(self, conn_id):
         """
         Run the tap in check mode and verify it succeeds.

--- a/tests/base.py
+++ b/tests/base.py
@@ -60,7 +60,7 @@ class HubspotBaseTest(unittest.TestCase):
             "companies": {
                 self.PRIMARY_KEYS: {"companyId"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"hs_lastmodifieddate"},
+                self.REPLICATION_KEYS: {"property_hs_lastmodifieddate"},
             },
             "contact_lists": {
                 self.PRIMARY_KEYS: {"listId"},
@@ -70,7 +70,8 @@ class HubspotBaseTest(unittest.TestCase):
             "contacts": {
                 self.PRIMARY_KEYS: {"vid"},  # DOCS_BUG listed in stitch docs as 'canonical-vid'
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"versionTimestamp"},  # DOCS_BUG  was commented out in OG tests
+                self.REPLICATION_KEYS: set(), # it doesn't appear in the catalog
+                # self.REPLICATION_KEYS: {"versionTimestamp"},  # DOCS_BUG  was commented out in OG tests
             },
             "contacts_by_company": {
                 self.PRIMARY_KEYS: {"company-id", "contact-id"},
@@ -83,17 +84,18 @@ class HubspotBaseTest(unittest.TestCase):
             "deals": {
                 self.PRIMARY_KEYS: {"dealId"},  # DOCS_BUG docs list 'dealId' and 'portalId
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"hs_lastmodifieddate"},
+                self.REPLICATION_KEYS: {"property_hs_lastmodifieddate"},
             },
             "email_events": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"startTimestamp"},  # DOCS_BUG docs list 'id' but OG tests use
+                self.REPLICATION_KEYS: set(),
+                # self.REPLICATION_KEYS: {"property_startTimestamp"},  # DOCS_BUG docs list 'id' but OG tests use
             },
             "engagements": {
                 self.PRIMARY_KEYS: {"engagement_id"},  # DOCS_BUG docs list 'id'
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"lastUpdated"},
+                self.REPLICATION_KEYS: {"engagement", 'lastUpdated'},
             },
             "forms": {
                 self.PRIMARY_KEYS: {"guid"},
@@ -108,7 +110,8 @@ class HubspotBaseTest(unittest.TestCase):
             "subscription_changes": {
                 self.PRIMARY_KEYS: {"timestamp", "portalId", "recipient"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"startTimestamp"},  # DOCS_BUG docs list 'timestamp'
+                self.REPLICATION_KEYS: set(),
+                # self.REPLICATION_KEYS: {"property_startTimestamp"},  # DOCS_BUG docs list 'timestamp'
             },
             "workflows": {
                 self.PRIMARY_KEYS: {"id"},
@@ -193,6 +196,10 @@ class HubspotBaseTest(unittest.TestCase):
         # Assert that the check job succeeded
         exit_status = menagerie.get_exit_status(conn_id, check_job_name)
         menagerie.verify_check_exit_status(self, exit_status, check_job_name)
+        return conn_id
+
+    def ensure_connection(self, original=True):
+        conn_id = connections.ensure_connection(self, original_properties = original)
         return conn_id
 
     def run_and_verify_check_mode(self, conn_id):

--- a/tests/base.py
+++ b/tests/base.py
@@ -59,18 +59,18 @@ class HubspotBaseTest(unittest.TestCase):
             },
             "companies": {
                 self.PRIMARY_KEYS: {"companyId"},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_METHOD: self.FULL,
                 self.REPLICATION_KEYS: set(),
                 # self.REPLICATION_KEYS: {"hs_lastmodifieddate"},
             },
             "contact_lists": {
                 self.PRIMARY_KEYS: {"listId"},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_METHOD: self.FULL,
                 self.REPLICATION_KEYS: {"updatedAt"},
             },
             "contacts": {
                 self.PRIMARY_KEYS: {"vid"},  # DOCS_BUG listed in stitch docs as 'canonical-vid'
-                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_METHOD: self.FULL,
                 self.REPLICATION_KEYS: set(), # it doesn't appear in the catalog
                 # self.REPLICATION_KEYS: {"versionTimestamp"},  # DOCS_BUG  was commented out in OG tests
             },
@@ -84,7 +84,7 @@ class HubspotBaseTest(unittest.TestCase):
             },
             "deals": {
                 self.PRIMARY_KEYS: {"dealId"},  # DOCS_BUG docs list 'dealId' and 'portalId
-                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_METHOD: self.FULL,
                 self.REPLICATION_KEYS: set(),
                 # Technically this is true, but `hs_lastmodifieddate` is a
                 # field on the `properties` object, and we don't select
@@ -95,33 +95,35 @@ class HubspotBaseTest(unittest.TestCase):
             "email_events": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
+                # self.REPLICATION_KEYS: {'startTimestamp'},
                 self.REPLICATION_KEYS: set(),
                 # self.REPLICATION_KEYS: {"property_startTimestamp"},  # DOCS_BUG docs list 'id' but OG tests use
             },
             "engagements": {
                 self.PRIMARY_KEYS: {"engagement_id"},  # DOCS_BUG docs list 'id'
-                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_METHOD: self.FULL,
                 self.REPLICATION_KEYS: {"engagement", "lastUpdated"},
             },
             "forms": {
                 self.PRIMARY_KEYS: {"guid"},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_METHOD: self.FULL,
                 self.REPLICATION_KEYS: {"updatedAt"},
             },
             "owners": {
                 self.PRIMARY_KEYS: {"ownerId"},  # DOCS_BUG docs list 'portalId'
-                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_METHOD: self.FULL,
                 self.REPLICATION_KEYS: {"updatedAt"},
             },
             "subscription_changes": {
                 self.PRIMARY_KEYS: {"timestamp", "portalId", "recipient"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
+                # self.REPLICATION_KEYS: {'startTimestamp'},
                 self.REPLICATION_KEYS: set(),
                 # self.REPLICATION_KEYS: {"property_startTimestamp"},  # DOCS_BUG docs list 'timestamp'
             },
             "workflows": {
                 self.PRIMARY_KEYS: {"id"},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_METHOD: self.FULL,
                 self.REPLICATION_KEYS: {"updatedAt"},
             }
         }

--- a/tests/base.py
+++ b/tests/base.py
@@ -233,7 +233,7 @@ class HubspotBaseTest(unittest.TestCase):
         self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
 
         found_catalog_names = set(map(lambda c: c['tap_stream_id'], found_catalogs))
-        self.assertSetEqual(self.expected_streams(), found_catalog_names,
+        self.assertSetEqual(self.expected_check_streams(), found_catalog_names,
                             msg="discovered schemas do not match")
         print("discovered schemas are OK")
 

--- a/tests/test_hubspot_all_fields_test.py
+++ b/tests/test_hubspot_all_fields_test.py
@@ -1,0 +1,72 @@
+import os
+import unittest
+
+from functools import reduce
+
+from singer import metadata
+import tap_tester.connections as connections
+import tap_tester.menagerie   as menagerie
+import tap_tester.runner      as runner
+
+from base import HubspotBaseTest
+
+
+class TestHubspotAllFields(HubspotBaseTest):
+    """Test that with all fields selected for a stream we replicate data as expected"""
+
+    def name(self):
+        return "tap_tester_all_fields_all_fields_test"
+
+    def testable_streams(self):
+        return {
+            'deals'
+        }
+
+    def test_run(self):
+        conn_id = self.ensure_connection()
+
+        # run in check mode
+        check_job_name = runner.run_check_mode(self, conn_id)
+
+        # verify check exit codes
+        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
+
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
+
+        # Select only the expected streams tables
+        expected_streams = self.testable_streams()
+        catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
+
+        for catalog_entry in catalog_entries:
+            stream_schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
+            connections.select_catalog_and_fields_via_metadata(
+                conn_id,
+                catalog_entry,
+                stream_schema
+            )
+
+        # run sync
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+
+        # Verify tap exit codes
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+
+        # read target output
+        first_record_count_by_stream = runner.examine_target_output_file(self, conn_id,
+                                                                         self.expected_streams(),
+                                                                         self.expected_primary_keys())
+        replicated_row_count =  reduce(lambda accum,c : accum + c, first_record_count_by_stream.values())
+        synced_records = runner.get_records_from_target_output()
+
+        # Test by Stream
+        for stream in self.testable_streams():
+            with self.subTest(stream=stream):
+
+                expected_fields = set(synced_records.get(stream)['schema']['properties'].keys())
+                print('Number of expected keys ', len(expected_fields))
+                actual_fields = set(runner.examine_target_output_for_fields()[stream])
+                print('Number of actual keys ', len(actual_fields))
+                self.assertSetEqual(expected_fields, actual_fields)

--- a/tests/test_hubspot_all_fields_test.py
+++ b/tests/test_hubspot_all_fields_test.py
@@ -39,7 +39,7 @@ class TestHubspotAllFields(HubspotBaseTest):
         }
 
     def test_run(self):
-        conn_id = connections.ensure_connection()
+        conn_id = connections.ensure_connection(self)
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 

--- a/tests/test_hubspot_all_fields_test.py
+++ b/tests/test_hubspot_all_fields_test.py
@@ -11,6 +11,28 @@ import tap_tester.runner      as runner
 from base import HubspotBaseTest
 
 
+KNOWN_MISSING_FIELDS = {
+    'deals': {
+        # This field requires attaching conferencing software to
+        # Hubspot and booking a meeting as part of a deal
+        'property_engagements_last_meeting_booked',
+        # These 3 fields are derived from UTM codes attached to the above
+        # meetings
+        'property_engagements_last_meeting_booked_campaign',
+        'property_engagements_last_meeting_booked_medium',
+        'property_engagements_last_meeting_booked_source',
+        # There's a way to associate a deal with a marketing campaign
+        'property_hs_campaign',
+        'property_hs_deal_amount_calculation_preference',
+        # These are calculated properties
+        'property_hs_likelihood_to_close',
+        'property_hs_merged_object_ids',
+        'property_hs_predicted_amount',
+        'property_hs_predicted_amount_in_home_currency',
+        'property_hs_sales_email_last_replied'
+    },
+}
+
 class TestHubspotAllFields(HubspotBaseTest):
     """Test that with all fields selected for a stream we replicate data as expected"""
 
@@ -19,7 +41,7 @@ class TestHubspotAllFields(HubspotBaseTest):
 
     def testable_streams(self):
         return {
-            'deals'
+            'deals',
         }
 
     def test_run(self):
@@ -69,4 +91,8 @@ class TestHubspotAllFields(HubspotBaseTest):
                 print('Number of expected keys ', len(expected_fields))
                 actual_fields = set(runner.examine_target_output_for_fields()[stream])
                 print('Number of actual keys ', len(actual_fields))
-                self.assertSetEqual(expected_fields, actual_fields)
+
+                unexpected_fields = actual_fields & KNOWN_MISSING_FIELDS[stream]
+                if unexpected_fields:
+                    print('WARNING: Found new fields: {}'.format(unexpected_fields))
+                self.assertSetEqual(expected_fields, actual_fields | KNOWN_MISSING_FIELDS[stream])

--- a/tests/test_hubspot_all_fields_test.py
+++ b/tests/test_hubspot_all_fields_test.py
@@ -64,7 +64,7 @@ class TestHubspotAllFields(HubspotBaseTest):
         # Run sync
         first_record_count_by_stream = self.run_and_verify_sync(conn_id)
 
-        replicated_row_count =  reduce(lambda accum,c : accum + c, first_record_count_by_stream.values())
+        replicated_row_count = sum(first_record_count_by_stream.values())
         synced_records = runner.get_records_from_target_output()
 
         # Test by Stream

--- a/tests/test_hubspot_all_fields_test.py
+++ b/tests/test_hubspot_all_fields_test.py
@@ -1,9 +1,3 @@
-import os
-import unittest
-
-from functools import reduce
-
-from singer import metadata
 import tap_tester.connections as connections
 import tap_tester.menagerie   as menagerie
 import tap_tester.runner      as runner

--- a/tests/test_hubspot_all_fields_test.py
+++ b/tests/test_hubspot_all_fields_test.py
@@ -45,7 +45,7 @@ class TestHubspotAllFields(HubspotBaseTest):
         }
 
     def test_run(self):
-        conn_id = self.ensure_connection()
+        conn_id = connections.ensure_connection()
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 

--- a/tests/test_hubspot_automatic_fields_test.py
+++ b/tests/test_hubspot_automatic_fields_test.py
@@ -27,7 +27,7 @@ class TestHubspotAutomaticFields(HubspotBaseTest):
 
 
     def test_run(self):
-        conn_id = connections.ensure_connection()
+        conn_id = connections.ensure_connection(self)
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 

--- a/tests/test_hubspot_automatic_fields_test.py
+++ b/tests/test_hubspot_automatic_fields_test.py
@@ -48,7 +48,7 @@ class TestHubspotAutomaticFields(HubspotBaseTest):
         has a workaround to skip the invalid assertion. See if block in
         test_run for details
         """
-        return self.expected_check_streams()
+        return self.expected_check_streams() - {'subscription_changes', 'email_events'}
 
 
     def test_run(self):

--- a/tests/test_hubspot_automatic_fields_test.py
+++ b/tests/test_hubspot_automatic_fields_test.py
@@ -105,6 +105,11 @@ class TestHubspotAutomaticFields(HubspotBaseTest):
         for stream in self.expected_streams():
             with self.subTest(stream=stream):
                 data = synced_records.get(stream)
+
+                if not data:
+                    print('WARNING: Add data for {}'.format(stream))
+                    continue
+
                 record_messages_keys = [set(row['data'].keys()) for row in data['messages']]
                 expected_keys = self.expected_automatic_fields().get(stream)
 
@@ -115,4 +120,5 @@ class TestHubspotAutomaticFields(HubspotBaseTest):
                         msg="Expected automatic fields and nothing else.")
 
                 # Verify the sync meets or exceeds the default record count
+                record_count = sync_record_count.get(stream, 0)
                 self.assertLessEqual(1, record_count)

--- a/tests/test_hubspot_automatic_fields_test.py
+++ b/tests/test_hubspot_automatic_fields_test.py
@@ -1,0 +1,118 @@
+import tap_tester.connections as connections
+import tap_tester.menagerie   as menagerie
+import tap_tester.runner      as runner
+import re
+
+from base import HubspotBaseTest
+
+class TestHubspotAutomaticFields(HubspotBaseTest):
+    def name(self):
+        return "tap_tester_hubspot_combined_test"
+
+    @staticmethod
+    def get_selected_fields_from_metadata(metadata):
+        selected_fields = set()
+        for field in metadata:
+            is_field_metadata = len(field['breadcrumb']) > 1
+            inclusion_automatic_or_selected = (field['metadata'].get('inclusion') == 'automatic'
+                                               or field['metadata'].get('selected') is True)
+            if is_field_metadata and inclusion_automatic_or_selected:
+                selected_fields.add(field['breadcrumb'][1])
+        return selected_fields
+
+    def get_properties(self):
+        return {
+            'start_date' : '2016-06-02T00:00:00Z',
+        }
+
+    def expected_check_streams(self):
+        return {
+            "subscription_changes",
+            "email_events",
+            "forms",
+            "workflows",
+            "owners",
+            "campaigns",
+            "contact_lists",
+            "contacts",
+            "companies",
+            "deals",
+            "engagements",
+            "deal_pipelines",
+            "contacts_by_company"
+        }
+
+    def expected_streams(self):
+        """
+        All streams are under test with the exception of 'budgets' which
+        has a workaround to skip the invalid assertion. See if block in
+        test_run for details
+        """
+        return self.expected_check_streams()
+
+
+    def test_run(self):
+        conn_id = self.ensure_connection()
+
+        # Run in check mode
+        check_job_name = runner.run_check_mode(self, conn_id)
+
+        # Verify check exit codes
+        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
+
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
+
+        # Select only the expected streams tables
+        expected_streams = self.expected_streams()
+        catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
+        self.select_all_streams_and_fields(conn_id, catalog_entries, select_all_fields=False)
+
+        # Verify our selection worked as expected
+        catalogs_selection = menagerie.get_catalogs(conn_id)
+        for cat in catalogs_selection:
+            catalog_entry = menagerie.get_annotated_schema(conn_id, cat['stream_id'])
+
+            # Verify the expected stream tables are selected
+            selected = catalog_entry.get('annotated-schema').get('selected')
+            print("Validating selection on {}: {}".format(cat['stream_name'], selected))
+            if cat['stream_name'] not in expected_streams:
+                self.assertFalse(selected, msg="Stream selected, but not testable.")
+                continue # Skip remaining assertions if we aren't selecting this stream
+            self.assertTrue(selected, msg="Stream not selected.")
+
+            # Verify only automatic fields are selected
+            expected_automatic_fields = self.expected_automatic_fields().get(cat['tap_stream_id'])
+            selected_fields = self.get_selected_fields_from_metadata(catalog_entry['metadata'])
+            self.assertEqual(expected_automatic_fields, selected_fields, msg='for stream {}, expected: {} actual: {}'.format(cat['stream_name'], expected_automatic_fields, selected_fields))
+
+        # Run a sync job using orchestrator
+
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+
+        # Verify tap and target exit codes
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+
+        # Get records that reached the target
+        sync_record_count = runner.examine_target_output_file(
+            self, conn_id, self.expected_streams(), self.expected_primary_keys())
+        synced_records = runner.get_records_from_target_output()
+
+        # Assert the records for each stream
+        for stream in self.expected_streams():
+            with self.subTest(stream=stream):
+                data = synced_records.get(stream)
+                record_messages_keys = [set(row['data'].keys()) for row in data['messages']]
+                expected_keys = self.expected_automatic_fields().get(stream)
+
+                # Verify that only the automatic fields are sent to the target
+                for actual_keys in record_messages_keys:
+                    self.assertEqual(
+                        actual_keys.symmetric_difference(expected_keys), set(),
+                        msg="Expected automatic fields and nothing else.")
+
+                # Verify the sync meets or exceeds the default record count
+                self.assertLessEqual(1, record_count)

--- a/tests/test_hubspot_automatic_fields_test.py
+++ b/tests/test_hubspot_automatic_fields_test.py
@@ -15,11 +15,6 @@ class TestHubspotAutomaticFields(HubspotBaseTest):
         }
 
     def expected_streams(self):
-        """
-        All streams are under test with the exception of 'budgets' which
-        has a workaround to skip the invalid assertion. See if block in
-        test_run for details
-        """
         return self.expected_check_streams().difference({
             'subscription_changes',
             'email_events',

--- a/tests/test_hubspot_automatic_fields_test.py
+++ b/tests/test_hubspot_automatic_fields_test.py
@@ -9,37 +9,9 @@ class TestHubspotAutomaticFields(HubspotBaseTest):
     def name(self):
         return "tap_tester_hubspot_combined_test"
 
-    @staticmethod
-    def get_selected_fields_from_metadata(metadata):
-        selected_fields = set()
-        for field in metadata:
-            is_field_metadata = len(field['breadcrumb']) > 1
-            inclusion_automatic_or_selected = (field['metadata'].get('inclusion') == 'automatic'
-                                               or field['metadata'].get('selected') is True)
-            if is_field_metadata and inclusion_automatic_or_selected:
-                selected_fields.add(field['breadcrumb'][1])
-        return selected_fields
-
     def get_properties(self):
         return {
             'start_date' : '2016-06-02T00:00:00Z',
-        }
-
-    def expected_check_streams(self):
-        return {
-            "subscription_changes",
-            "email_events",
-            "forms",
-            "workflows",
-            "owners",
-            "campaigns",
-            "contact_lists",
-            "contacts",
-            "companies",
-            "deals",
-            "engagements",
-            "deal_pipelines",
-            "contacts_by_company"
         }
 
     def expected_streams(self):

--- a/tests/test_hubspot_automatic_fields_test.py
+++ b/tests/test_hubspot_automatic_fields_test.py
@@ -27,7 +27,7 @@ class TestHubspotAutomaticFields(HubspotBaseTest):
 
 
     def test_run(self):
-        conn_id = self.ensure_connection()
+        conn_id = connections.ensure_connection()
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 

--- a/tests/test_hubspot_automatic_fields_test.py
+++ b/tests/test_hubspot_automatic_fields_test.py
@@ -48,7 +48,15 @@ class TestHubspotAutomaticFields(HubspotBaseTest):
         has a workaround to skip the invalid assertion. See if block in
         test_run for details
         """
-        return self.expected_check_streams() - {'subscription_changes', 'email_events'}
+        return self.expected_check_streams().difference({
+            'subscription_changes',
+            'email_events',
+            'companies',
+            'contacts',
+            'deals',
+            'engagements',
+            'contacts_by_company',
+        })
 
 
     def test_run(self):

--- a/tests/test_hubspot_bookmarks1.py
+++ b/tests/test_hubspot_bookmarks1.py
@@ -52,23 +52,6 @@ class HubSpotBookmarks1(HubspotBaseTest):
             "contacts_by_company",
         }
 
-    def expected_check_streams(self):
-        return {
-            "subscription_changes",
-            "email_events",
-            "forms",
-            "workflows",
-            "owners",
-            "campaigns",
-            "contact_lists",
-            "contacts",
-            "companies",
-            "deals",
-            "engagements",
-            "deal_pipelines",
-            "contacts_by_company"
-        }
-
     def expected_sync_streams(self):
         return {
             #"subscription_changes",

--- a/tests/test_hubspot_bookmarks1.py
+++ b/tests/test_hubspot_bookmarks1.py
@@ -19,23 +19,6 @@ class HubSpotBookmarks1(HubspotBaseTest):
     def get_properties(self):  # TODO Determine if we can move this forward so it syncs quicker
         return {'start_date' : '2017-05-01T00:00:00Z'}
 
-    def expected_pks(self):
-        return {
-            "subscription_changes" : {"timestamp", "portalId", "recipient"},
-            "email_events" :         {'id'},
-            "forms" :                {"guid"},
-            "workflows" :            {"id"},
-            "owners" :               {"ownerId"},
-            "campaigns" :            {"id"},
-            "contact_lists":         {"listId"},
-            "contacts" :             {'vid'},
-            "companies":             {"companyId"},
-            "deals":                 {"dealId"},
-            "engagements":           {"engagement_id"},
-            "contacts_by_company" : {"company-id", "contact-id"},
-            "deal_pipelines" : {"pipelineId"},
-        }
-
     def acceptable_bookmarks(self):
         return {
             "subscription_changes",
@@ -164,7 +147,7 @@ class HubSpotBookmarks1(HubspotBaseTest):
         exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
         menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
 
-        record_count_by_stream = runner.examine_target_output_file(self, conn_id, self.expected_sync_streams(), self.expected_pks())
+        record_count_by_stream = runner.examine_target_output_file(self, conn_id, self.expected_sync_streams(), self.expected_primary_keys())
         replicated_row_count =  reduce(lambda accum,c : accum + c, record_count_by_stream.values())
         self.assertGreater(replicated_row_count, 0, msg="failed to replicate any data: {}".format(record_count_by_stream))
         print("total replicated row count: {}".format(replicated_row_count))

--- a/tests/test_hubspot_bookmarks1.py
+++ b/tests/test_hubspot_bookmarks1.py
@@ -71,8 +71,8 @@ class HubSpotBookmarks1(HubspotBaseTest):
 
     def expected_sync_streams(self):
         return {
-            "subscription_changes",
-            "email_events",
+            #"subscription_changes",
+            #"email_events",
             "forms",
             "workflows",
             "owners",
@@ -127,13 +127,13 @@ class HubSpotBookmarks1(HubspotBaseTest):
     def expected_bookmarks(self):
         return {'deals' :         ['hs_lastmodifieddate'],
                 'contact_lists' : ['updatedAt'],
-                'email_events' :  ['startTimestamp'],
+                # 'email_events' :  ['startTimestamp'],
                 # 'contacts':       ['versionTimestamp'],
                 'workflows':      ['updatedAt'],
                 'campaigns':      [],
                 'contacts_by_company' : [],
                 'owners' :        ['updatedAt'],
-                'subscription_changes':  ['startTimestamp'],
+                # 'subscription_changes':  ['startTimestamp'],
                 'engagements' :          ['lastUpdated'],
                 'companies'  :           ['hs_lastmodifieddate'],
                 'forms'      :           ['updatedAt'] }
@@ -169,7 +169,8 @@ class HubSpotBookmarks1(HubspotBaseTest):
 
         # Select all Catalogs
         for catalog in found_catalogs:
-            connections.select_catalog_and_fields_via_metadata(conn_id, catalog, menagerie.get_annotated_schema(conn_id, catalog['stream_id']))
+            if catalog['tap_stream_id'] in self.expected_sync_streams():
+                connections.select_catalog_and_fields_via_metadata(conn_id, catalog, menagerie.get_annotated_schema(conn_id, catalog['stream_id']))
 
         #clear state
         menagerie.set_state(conn_id, {})
@@ -205,7 +206,9 @@ class HubSpotBookmarks1(HubspotBaseTest):
         for k,v in sorted(list(self.expected_bookmarks().items())):
             for w in v:
                 bk_value = bookmarks.get(k,{}).get(w)
-                self.assertEqual(utils.strptime_with_tz(bk_value), utils.strptime_with_tz(max_bookmarks_from_records[k]), "Bookmark {} ({}) for stream {} should have been updated to {}".format(bk_value, w, k, max_bookmarks_from_records[k]))
+                self.assertEqual(utils.strptime_with_tz(bk_value),
+                                 utils.strptime_with_tz(max_bookmarks_from_records[k]),
+                                 "Bookmark {} ({}) for stream {} should have been updated to {}".format(bk_value, w, k, max_bookmarks_from_records[k]))
                 print("bookmark {}({}) updated to {} from max record value {}".format(k, w, bk_value, max_bookmarks_from_records[k]))
 
         for k,v in self.expected_offsets().items():

--- a/tests/test_hubspot_bookmarks1.py
+++ b/tests/test_hubspot_bookmarks1.py
@@ -104,16 +104,6 @@ class HubSpotBookmarks1(HubspotBaseTest):
                 'companies'  :           ['hs_lastmodifieddate'],
                 'forms'      :           ['updatedAt'] }
 
-
-    def perform_field_selection(self, conn_id, catalog):
-        schema = menagerie.select_catalog(conn_id, catalog)
-
-        return {'key_properties' :     catalog.get('key_properties'),
-                'schema' :             schema,
-                'tap_stream_id':       catalog.get('tap_stream_id'),
-                'replication_method' : catalog.get('replication_method'),
-                'replication_key'    : catalog.get('replication_key')}
-
     def test_run(self):
         conn_id = connections.ensure_connection(self)
 

--- a/tests/test_hubspot_bookmarks2.py
+++ b/tests/test_hubspot_bookmarks2.py
@@ -5,7 +5,9 @@ import tap_tester.runner      as runner
 import os
 import unittest
 
-class HubSpotBookmarks2(unittest.TestCase):
+from base import HubspotBaseTest
+
+class HubSpotBookmarks2(HubspotBaseTest):
 
     def name(self):
         return "tap_tester_hub_bookmarks_2"

--- a/tests/test_hubspot_bookmarks2.py
+++ b/tests/test_hubspot_bookmarks2.py
@@ -66,8 +66,8 @@ class HubSpotBookmarks2(unittest.TestCase):
 
     def expected_sync_streams(self):
         return {
-            "subscription_changes",
-            "email_events",
+            # "subscription_changes",
+            # "email_events",
             "forms",
             "workflows",
             "owners",

--- a/tests/test_hubspot_bookmarks2.py
+++ b/tests/test_hubspot_bookmarks2.py
@@ -56,7 +56,7 @@ class HubSpotBookmarks2(HubspotBaseTest):
         return {'start_date' : '2017-05-01T00:00:00Z'}
 
     def test_run(self):
-        conn_id = connections.ensure_connection()
+        conn_id = connections.ensure_connection(self)
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 

--- a/tests/test_hubspot_bookmarks2.py
+++ b/tests/test_hubspot_bookmarks2.py
@@ -48,22 +48,6 @@ class HubSpotBookmarks2(unittest.TestCase):
             "deal_pipelines" : {"pipelineId"},
         }
 
-    def expected_check_streams(self):
-        return {
-            "subscription_changes",
-            "email_events",
-            "forms",
-            "workflows",
-            "owners",
-            "campaigns",
-            "contact_lists",
-            "contacts",
-            "companies",
-            "deals",
-            "engagements",
-            "deal_pipelines",
-            "contacts_by_company"}
-
     def expected_sync_streams(self):
         return {
             # "subscription_changes",

--- a/tests/test_hubspot_bookmarks2.py
+++ b/tests/test_hubspot_bookmarks2.py
@@ -56,7 +56,7 @@ class HubSpotBookmarks2(HubspotBaseTest):
         return {'start_date' : '2017-05-01T00:00:00Z'}
 
     def test_run(self):
-        conn_id = connections.ensure_connection(self)
+        conn_id = connections.ensure_connection()
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 

--- a/tests/test_hubspot_bookmarks2.py
+++ b/tests/test_hubspot_bookmarks2.py
@@ -75,15 +75,6 @@ class HubSpotBookmarks2(unittest.TestCase):
     def get_properties(self):
         return {'start_date' : '2017-05-01T00:00:00Z'}
 
-    def perform_field_selection(self, conn_id, catalog):
-        schema = menagerie.select_catalog(conn_id, catalog)
-
-        return {'key_properties' :     catalog.get('key_properties'),
-                'schema' :             schema,
-                'tap_stream_id':       catalog.get('tap_stream_id'),
-                'replication_method' : catalog.get('replication_method'),
-                'replication_key'    : catalog.get('replication_key')}
-
     def test_run(self):
         conn_id = connections.ensure_connection(self)
 

--- a/tests/test_hubspot_bookmarks2.py
+++ b/tests/test_hubspot_bookmarks2.py
@@ -6,31 +6,9 @@ import os
 import unittest
 
 class HubSpotBookmarks2(unittest.TestCase):
-    # TODO Go through test and update to use base.py
-    def setUp(self):
-        missing_envs = [x for x in [os.getenv('TAP_HUBSPOT_REDIRECT_URI'),
-                                    os.getenv('TAP_HUBSPOT_CLIENT_ID'),
-                                    os.getenv('TAP_HUBSPOT_CLIENT_SECRET'),
-                                    os.getenv('TAP_HUBSPOT_REFRESH_TOKEN')] if x == None]
-        if len(missing_envs) != 0:
-            #pylint: disable=line-too-long
-            raise Exception("set TAP_HUBSPOT_REDIRECT_URI, TAP_HUBSPOT_CLIENT_ID, TAP_HUBSPOT_CLIENT_SECRET, TAP_HUBSPOT_REFRESH_TOKEN")
 
     def name(self):
         return "tap_tester_hub_bookmarks_2"
-
-    def tap_name(self):
-        return "tap-hubspot"
-
-    def get_type(self):
-        return "platform.hubspot"
-
-    def get_credentials(self):
-        return {'refresh_token': os.getenv('TAP_HUBSPOT_REFRESH_TOKEN'),
-                'client_secret': os.getenv('TAP_HUBSPOT_CLIENT_SECRET'),
-                'redirect_uri':  os.getenv('TAP_HUBSPOT_REDIRECT_URI'),
-                'client_id':     os.getenv('TAP_HUBSPOT_CLIENT_ID')}
-
 
     def expected_sync_streams(self):
         return {

--- a/tests/test_hubspot_bookmarks2.py
+++ b/tests/test_hubspot_bookmarks2.py
@@ -56,21 +56,7 @@ class HubSpotBookmarks2(unittest.TestCase):
     def test_run(self):
         conn_id = connections.ensure_connection(self)
 
-        #run in check mode
-        check_job_name = runner.run_check_mode(self, conn_id)
-
-        #verify check  exit codes
-        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
-        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
-
-        found_catalogs = menagerie.get_catalogs(conn_id)
-        self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
-
-        found_catalog_names = set(map(lambda c: c['tap_stream_id'], found_catalogs))
-
-        diff = self.expected_check_streams().symmetric_difference( found_catalog_names )
-        self.assertEqual(len(diff), 0, msg="discovered schemas do not match: {}".format(diff))
-        print("discovered schemas are kosher")
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
 
         #select all catalogs
         for catalog in found_catalogs:
@@ -101,13 +87,7 @@ class HubSpotBookmarks2(unittest.TestCase):
 
         menagerie.set_state(conn_id, future_bookmarks)
 
-        sync_job_name = runner.run_sync_mode(self, conn_id)
-
-        #verify tap and target exit codes
-        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
-        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
-
-        record_count_by_stream = runner.examine_target_output_file(self, conn_id, self.expected_sync_streams(), self.expected_primary_keys())
+        record_count_by_stream = self.run_and_verify_sync(conn_id)
 
         #because the bookmarks were set into the future, we should NOT actually replicate any data.
         #minus campaigns, and deal_pipelines because those endpoints do NOT suppport bookmarks

--- a/tests/test_hubspot_bookmarks2.py
+++ b/tests/test_hubspot_bookmarks2.py
@@ -31,22 +31,6 @@ class HubSpotBookmarks2(unittest.TestCase):
                 'redirect_uri':  os.getenv('TAP_HUBSPOT_REDIRECT_URI'),
                 'client_id':     os.getenv('TAP_HUBSPOT_CLIENT_ID')}
 
-    def expected_pks(self):
-        return {
-            "subscription_changes" : {"timestamp", "portalId", "recipient"},
-            "email_events" :         {'id'},
-            "forms" :                {"guid"},
-            "workflows" :            {"id"},
-            "owners" :               {"ownerId"},
-            "campaigns" :            {"id"},
-            "contact_lists":         {"listId"},
-            "contacts" :             {'vid'},
-            "companies":             {"companyId"},
-            "deals":                 {"dealId"},
-            "engagements":           {"engagement_id"},
-            "contacts_by_company" : {"company-id", "contact-id"},
-            "deal_pipelines" : {"pipelineId"},
-        }
 
     def expected_sync_streams(self):
         return {
@@ -154,7 +138,7 @@ class HubSpotBookmarks2(unittest.TestCase):
         exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
         menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
 
-        record_count_by_stream = runner.examine_target_output_file(self, conn_id, self.expected_sync_streams(), self.expected_pks())
+        record_count_by_stream = runner.examine_target_output_file(self, conn_id, self.expected_sync_streams(), self.expected_primary_keys())
 
         #because the bookmarks were set into the future, we should NOT actually replicate any data.
         #minus campaigns, and deal_pipelines because those endpoints do NOT suppport bookmarks

--- a/tests/test_hubspot_discovery.py
+++ b/tests/test_hubspot_discovery.py
@@ -5,6 +5,7 @@ from tap_tester import menagerie
 
 from base import HubspotBaseTest
 
+import singer
 
 class DiscoveryTest(HubspotBaseTest):
     """Test tap discovery mode and metadata/annotated-schema conforms to standards."""
@@ -68,98 +69,78 @@ class DiscoveryTest(HubspotBaseTest):
                 assert catalog  # based on previous tests this should always be found
 
                 schema_and_metadata = menagerie.get_annotated_schema(conn_id, catalog['stream_id'])
-                metadata = schema_and_metadata["metadata"]
+                metadata = singer.metadata.to_map(schema_and_metadata["metadata"])
                 schema = schema_and_metadata["annotated-schema"]
 
                 # verify there is only 1 top level breadcrumb
-                stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
+                # stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
+                stream_properties = [item for item in metadata if item == ()]
                 self.assertTrue(len(stream_properties) == 1,
                                 msg="There is NOT only one top level breadcrumb for {}".format(stream) + \
                                 "\nstream_properties | {}".format(stream_properties))
 
-                # verify replication key(s)
-                self.assertEqual(
-                    set(stream_properties[0].get(
-                        "metadata", {self.REPLICATION_KEYS: []}).get(self.REPLICATION_KEYS, [])),
-                    self.expected_replication_keys()[stream],
-                    msg="expected replication key {} but actual is {}".format(
-                        self.expected_replication_keys()[stream],
-                        set(stream_properties[0].get(
-                            "metadata", {self.REPLICATION_KEYS: None}).get(
-                                self.REPLICATION_KEYS, []))))
 
-                # verify primary key(s)
-                self.assertEqual(
-                    set(stream_properties[0].get(
-                        "metadata", {self.PRIMARY_KEYS: []}).get(self.PRIMARY_KEYS, [])),
-                    self.expected_primary_keys()[stream],
-                    msg="expected primary key {} but actual is {}".format(
-                        self.expected_primary_keys()[stream],
-                        set(stream_properties[0].get(
-                            "metadata", {self.PRIMARY_KEYS: None}).get(self.PRIMARY_KEYS, []))))
+                stream_replication_method = metadata[()].get(self.REPLICATION_METHOD)
+                if stream_replication_method == self.INCREMENTAL:
+                    # verify replication key(s) for incremental streams
+                    expected_value = self.expected_replication_keys()[stream]
+                    actual_value = set(metadata[()].get(self.REPLICATION_KEYS, []))
 
-                # BUG_1 (https://stitchdata.atlassian.net/browse/SRCE-4490)
-                # # verify the actual replication matches our expected replication method
-                # self.assertEqual(
-                #     self.expected_replication_method().get(stream, None),
-                #     actual_replication_method,
-                #     msg="The actual replication method {} doesn't match the expected {}".format(
-                #         actual_replication_method,
-                #         self.expected_replication_method().get(stream, None)))
-
-                # verify that if there is a replication key we are doing INCREMENTAL otherwise FULL
-                actual_replication_method = stream_properties[0].get(
-                    "metadata", {self.REPLICATION_METHOD: None}).get(self.REPLICATION_METHOD)
-                if stream_properties[0].get(
-                        "metadata", {self.REPLICATION_KEYS: []}).get(self.REPLICATION_KEYS, []):
                     # BUG_1 (https://stitchdata.atlassian.net/browse/SRCE-4490)
-                    pass  # TODO Remove me when bug is addressed
+                    # self.assertEqual(expected_value,
+                    #                  actual_value,
+                    #                  msg="expected replication key {} but actual is {}".format(expected_value,
+                    #                                                                            actual_value))
+
                     # self.assertTrue(actual_replication_method == self.INCREMENTAL,
                     #                 msg="Expected INCREMENTAL replication "
                     #                     "since there is a replication key")
+                elif stream_replication_method == self.FULL:
+                    pass
                 else:
-                    self.assertTrue(actual_replication_method == self.FULL,
-                                    msg="Expected FULL replication "
-                                        "since there is no replication key")
+                    raise AssertionError('Expected replication method to be incremental or full, got {}'.format(stream_replication_method))
+
+                # verify the actual replication matches our expected replication method
+                self.assertEqual(
+                    self.expected_replication_method().get(stream, None),
+                    stream_replication_method,
+                    msg="The actual replication method {} doesn't match the expected {}".format(
+                        stream_replication_method,
+                        self.expected_replication_method().get(stream, None)))
+
 
                 expected_primary_keys = self.expected_primary_keys()[stream]
                 expected_replication_keys = self.expected_replication_keys()[stream]
                 expected_automatic_fields = expected_primary_keys | expected_replication_keys
 
-                # verify that primary, replication and foreign keys
-                # are given the inclusion of automatic in annotated schema.
-                # BUG_2 (https://stitchdata.atlassian.net/browse/SRCE-4495)
-                actual_automatic_fields = {key for key, value in schema["properties"].items()
-                                           if value.get("inclusion") == "automatic"}
-                # self.assertEqual(expected_automatic_fields, actual_automatic_fields)
-                         
-
-                # verify that all other fields have inclusion of available
-                # This assumes there are no unsupported fields for SaaS sources
-                self.assertTrue(
-                    all({value.get("inclusion") == "available" for key, value
-                         in schema["properties"].items()
-                         if key not in actual_automatic_fields}),
-                    msg="Not all non key properties are set to available in annotated schema")
+                # verify primary key(s)
+                actual_primary_keys = set(metadata[()].get(self.PRIMARY_KEYS))
+                self.assertEqual(expected_primary_keys,
+                                 actual_primary_keys,
+                                 msg="expected primary key {} but actual is {}".format(expected_primary_keys,
+                                                                                       actual_primary_keys))
 
                 # verify that primary, replication and foreign keys
                 # are given the inclusion of automatic in metadata.
                 # BUG_2 (https://stitchdata.atlassian.net/browse/SRCE-4495)
-                actual_automatic_fields = {item.get("breadcrumb", ["properties", None])[1]
-                                           for item in metadata
-                                           if item.get("metadata").get("inclusion") == "automatic"}
-                # self.assertEqual(expected_automatic_fields,
-                #                  actual_automatic_fields,
-                #                  msg="expected {} automatic fields but got {}".format(
-                #                      expected_automatic_fields,
-                #                      actual_automatic_fields))
+                actual_automatic_fields = {breadcrumb[1]
+                                           for breadcrumb, mdata in metadata.items()
+                                           if mdata.get('inclusion') == "automatic"}
+                self.assertEqual(expected_automatic_fields,
+                                 actual_automatic_fields,
+                                 msg="expected {} automatic fields but got {}".format(
+                                     expected_automatic_fields,
+                                     actual_automatic_fields))
 
-                # verify that all other fields have inclusion of available
+                # verify that all other fields have of available inclusion
                 # This assumes there are no unsupported fields for SaaS sources
-                self.assertTrue(
-                    all({item.get("metadata").get("inclusion") == "available"
-                         for item in metadata
-                         if item.get("breadcrumb", []) != []
-                         and item.get("breadcrumb", ["properties", None])[1]
-                         not in actual_automatic_fields}),
-                    msg="Not all non key properties are set to available in metadata")
+                for breadcrumb, mdata in metadata.items():
+                    if breadcrumb == ():
+                        continue
+                    field_name = breadcrumb[1]
+                    if mdata.get('inclusion') == 'automatic':
+                        self.assertTrue(field_name in expected_automatic_fields)
+                    elif mdata.get('inclusion') == 'available':
+                        self.assertFalse(field_name in expected_automatic_fields)
+                    else:
+                        raise AssertionError('{} is not inclusion automatic or available'.format(field_name))

--- a/tests/test_hubspot_discovery.py
+++ b/tests/test_hubspot_discovery.py
@@ -34,30 +34,11 @@ class DiscoveryTest(HubspotBaseTest):
 
         conn_id = self.create_connection()
 
-        # Verify number of actual streams discovered match expected
-        catalogs = menagerie.get_catalogs(conn_id)
-        found_catalogs = [catalog for catalog in catalogs
-                          if catalog.get('tap_stream_id') in streams_to_test]
-
-        self.assertGreater(len(found_catalogs), 0,
-                           msg="unable to locate schemas for connection {}".format(conn_id))
-        self.assertEqual(len(found_catalogs),
-                         len(streams_to_test),
-                         msg="Expected {} streams, actual was {} for connection {}, "
-                             "actual {}".format(
-                                 len(streams_to_test),
-                                 len(found_catalogs),
-                                 found_catalogs,
-                                 conn_id))
-
-        # Verify the stream names discovered were what we expect
-        found_catalog_names = {c['tap_stream_id'] for c in found_catalogs}
-        self.assertEqual(set(streams_to_test),
-                         set(found_catalog_names),
-                         msg="Expected streams don't match actual streams")
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
 
         # Verify stream names follow naming convention
         # streams should only have lowercase alphas and underscores
+        found_catalog_names = {c['tap_stream_id'] for c in found_catalogs}
         self.assertTrue(all([re.fullmatch(r"[a-z_]+", name) for name in found_catalog_names]),
                         msg="One or more streams don't follow standard naming")
 
@@ -132,7 +113,7 @@ class DiscoveryTest(HubspotBaseTest):
                 actual_automatic_fields = {key for key, value in schema["properties"].items()
                                            if value.get("inclusion") == "automatic"}
                 # self.assertEqual(expected_automatic_fields, actual_automatic_fields)
-                         
+
 
                 # verify that all other fields have inclusion of available
                 # This assumes there are no unsupported fields for SaaS sources

--- a/tests/test_hubspot_pagination_test.py
+++ b/tests/test_hubspot_pagination_test.py
@@ -46,7 +46,7 @@ class TestHubspotPagination(HubspotBaseTest):
 
 
     def test_run(self):
-        conn_id = self.ensure_connection()
+        conn_id = connections.ensure_connection()
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 

--- a/tests/test_hubspot_pagination_test.py
+++ b/tests/test_hubspot_pagination_test.py
@@ -1,0 +1,121 @@
+import tap_tester.connections as connections
+import tap_tester.menagerie   as menagerie
+import tap_tester.runner      as runner
+
+from base import HubspotBaseTest
+
+
+class TestHubspotPagination(HubspotBaseTest):
+    def name(self):
+        return "tap_tester_hubspot_pagination_test"
+
+    def expected_check_streams(self):
+        return {
+            "subscription_changes",
+            "email_events",
+            "forms",
+            "workflows",
+            "owners",
+            "campaigns",
+            "contact_lists",
+            "contacts",
+            "companies",
+            "deals",
+            "engagements",
+            "deal_pipelines",
+            "contacts_by_company"
+        }
+
+    def expected_page_size(self):
+        return {
+            # "subscription_changes": 10 - 1000,
+            "subscription_changes": 1000,
+            # "email_events": 10 - 1000,
+            "email_events": 1000,
+            # "forms": ??, #infinity
+            # "workflows": ??,
+            # "owners": ??,
+            # "campaigns": ??,
+            # "campaigns": 500, # Can't make test data
+            # "contact_lists": 20 - 250,  #count,
+            # "deal_pipelines": ?? , # deprecated
+            # "contacts_by_company": 100,  #count # deprecated
+            "contact_lists": 250,
+            "contacts": 100, #count
+            "companies": 250,
+            "deals": 100,
+            "engagements": 250,
+        }
+
+    def expected_streams(self):
+        """
+        All streams are under test
+        """
+        return set(self.expected_page_size().keys()).difference({
+            'subscription_changes',
+            'email_events',
+        })
+
+    def get_properties(self):
+        return {
+            'start_date' : '2017-01-01T00:00:00Z',
+        }
+
+
+    def test_run(self):
+        conn_id = self.ensure_connection()
+
+        # Run in check mode
+        check_job_name = runner.run_check_mode(self, conn_id)
+
+        # Verify check exit codes
+        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
+
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
+
+        # Select only the expected streams tables
+        expected_streams = self.expected_streams()
+        catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
+        self.select_all_streams_and_fields(conn_id, catalog_entries, select_all_fields=True)
+
+        for catalog_entry in catalog_entries:
+            stream_schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
+            connections.select_catalog_and_fields_via_metadata(
+                conn_id,
+                catalog_entry,
+                stream_schema
+            )
+
+        # Run a sync job using orchestrator
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+
+        # Verify tap and target exit codes
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+
+        # Examine target file
+        sync_records = runner.get_records_from_target_output()
+        sync_record_count = runner.examine_target_output_file(
+            self, conn_id, self.expected_streams(), self.expected_primary_keys())
+
+        # Test by stream
+        for stream in self.expected_streams():
+            with self.subTest(stream=stream):
+
+                record_count = sync_record_count.get(stream, 0)
+
+                sync_messages = sync_records.get(stream, {'messages': []}).get('messages')
+
+                primary_key = self.expected_primary_keys().get(stream).pop()
+
+                # Verify the sync meets or exceeds the default record count
+                stream_page_size = self.expected_page_size()[stream]
+                self.assertLessEqual(stream_page_size, record_count)
+
+                # Verify we did not duplicate any records across pages
+                records_pks_set = {message.get('data').get(primary_key) for message in sync_messages}
+                records_pks_list = [message.get('data').get(primary_key) for message in sync_messages]
+                self.assertCountEqual(records_pks_set, records_pks_list,
+                                      msg="We have duplicate records for {}".format(stream))

--- a/tests/test_hubspot_pagination_test.py
+++ b/tests/test_hubspot_pagination_test.py
@@ -46,7 +46,7 @@ class TestHubspotPagination(HubspotBaseTest):
 
 
     def test_run(self):
-        conn_id = connections.ensure_connection()
+        conn_id = connections.ensure_connection(self)
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 

--- a/tests/test_hubspot_pagination_test.py
+++ b/tests/test_hubspot_pagination_test.py
@@ -48,40 +48,16 @@ class TestHubspotPagination(HubspotBaseTest):
     def test_run(self):
         conn_id = self.ensure_connection()
 
-        # Run in check mode
-        check_job_name = runner.run_check_mode(self, conn_id)
-
-        # Verify check exit codes
-        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
-        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
-
-        found_catalogs = menagerie.get_catalogs(conn_id)
-        self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
 
         # Select only the expected streams tables
         expected_streams = self.expected_streams()
         catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
         self.select_all_streams_and_fields(conn_id, catalog_entries, select_all_fields=True)
 
-        for catalog_entry in catalog_entries:
-            stream_schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
-            connections.select_catalog_and_fields_via_metadata(
-                conn_id,
-                catalog_entry,
-                stream_schema
-            )
-
-        # Run a sync job using orchestrator
-        sync_job_name = runner.run_sync_mode(self, conn_id)
-
-        # Verify tap and target exit codes
-        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
-        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
-
-        # Examine target file
+        sync_record_count = self.run_and_verify_sync(conn_id)
         sync_records = runner.get_records_from_target_output()
-        sync_record_count = runner.examine_target_output_file(
-            self, conn_id, self.expected_streams(), self.expected_primary_keys())
+
 
         # Test by stream
         for stream in self.expected_streams():

--- a/tests/test_hubspot_pagination_test.py
+++ b/tests/test_hubspot_pagination_test.py
@@ -112,7 +112,7 @@ class TestHubspotPagination(HubspotBaseTest):
 
                 # Verify the sync meets or exceeds the default record count
                 stream_page_size = self.expected_page_size()[stream]
-                self.assertLessEqual(stream_page_size, record_count)
+                self.assertLess(stream_page_size, record_count)
 
                 # Verify we did not duplicate any records across pages
                 records_pks_set = {message.get('data').get(primary_key) for message in sync_messages}

--- a/tests/test_hubspot_pagination_test.py
+++ b/tests/test_hubspot_pagination_test.py
@@ -9,23 +9,6 @@ class TestHubspotPagination(HubspotBaseTest):
     def name(self):
         return "tap_tester_hubspot_pagination_test"
 
-    def expected_check_streams(self):
-        return {
-            "subscription_changes",
-            "email_events",
-            "forms",
-            "workflows",
-            "owners",
-            "campaigns",
-            "contact_lists",
-            "contacts",
-            "companies",
-            "deals",
-            "engagements",
-            "deal_pipelines",
-            "contacts_by_company"
-        }
-
     def expected_page_size(self):
         return {
             # "subscription_changes": 10 - 1000,

--- a/tests/test_hubspot_start_date_test.py
+++ b/tests/test_hubspot_start_date_test.py
@@ -1,0 +1,108 @@
+import tap_tester.connections as connections
+import tap_tester.menagerie   as menagerie
+import tap_tester.runner      as runner
+
+from base import HubspotBaseTest
+
+class TestHubspotStartDate(HubspotBaseTest):
+    def name(self):
+        return "tap_tester_hubspot_combined_test"
+
+    def expected_check_streams(self):
+        return {
+            "subscription_changes",
+            "email_events",
+            "forms",
+            "workflows",
+            "owners",
+            "campaigns",
+            "contact_lists",
+            "contacts",
+            "companies",
+            "deals",
+            "engagements",
+            "deal_pipelines",
+            "contacts_by_company"
+        }
+
+    def expected_streams(self):
+        """All streams are under test"""
+        return self.expected_check_streams()
+
+    def get_properties(self, original=True):
+        if original:
+            return {
+                'start_date' : '2016-06-02T00:00:00Z',
+            }
+        else:
+            return {
+                'start_date' : '2020-11-01T00:00:00Z',
+            }
+
+
+    def test_run(self):
+        # SYNC 1
+        conn_id = self.ensure_connection()
+
+        # Run in check mode
+        check_job_name = runner.run_check_mode(self, conn_id)
+
+        # Verify check exit codes
+        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
+
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
+
+        # Select only the expected streams tables
+        expected_streams = self.expected_streams()
+        catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
+        self.select_all_streams_and_fields(conn_id, catalog_entries)
+
+        # Run a sync job using orchestrator
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+        first_sync_records = runner.get_records_from_target_output()
+        first_sync_record_count = runner.examine_target_output_file(
+            self, conn_id, self.expected_streams(), self.expected_primary_keys())
+
+        # Verify tap and target exit codes
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+
+        # SYNC 2
+        conn_id = self.ensure_connection(original=False)
+
+        # Run in check mode
+        check_job_name = runner.run_check_mode(self, conn_id)
+
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
+        self.select_all_streams_and_fields(conn_id, catalog_entries)
+
+        # Run in Sync mode
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+        second_sync_records = runner.get_records_from_target_output()
+        second_sync_record_count = runner.examine_target_output_file(
+            self, conn_id, self.expected_streams(), self.expected_primary_keys())
+
+        # Verify tap and target exit codes
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+
+        # Test by stream
+        for stream in self.expected_streams():
+            with self.subTest(stream=stream):
+                # record counts
+                first_sync_count = first_sync_record_count.get(stream, 0)
+                second_sync_count = second_sync_record_count.get(stream, 0)
+
+                # record messages
+                first_sync_messages = first_sync_records.get(stream, {'messages': []}).get('messages')
+                second_sync_messages = second_sync_records.get(stream, {'messages': []}).get('messages')
+
+                # start dates
+                start_date_1 = self.get_properties()['start_date']
+                start_date_2 = self.get_properties(original=False)['start_date']
+
+                # Verify by stream more records were replicated in the first sync, with an older start_date than the second
+                self.assertGreaterEqual(first_sync_count, second_sync_count)

--- a/tests/test_hubspot_start_date_test.py
+++ b/tests/test_hubspot_start_date_test.py
@@ -27,7 +27,8 @@ class TestHubspotStartDate(HubspotBaseTest):
 
     def expected_streams(self):
         """All streams are under test"""
-        return self.expected_check_streams()
+        return self.expected_check_streams() - {'subscription_changes', 'email_events'}
+
 
     def get_properties(self, original=True):
         if original:

--- a/tests/test_hubspot_start_date_test.py
+++ b/tests/test_hubspot_start_date_test.py
@@ -104,5 +104,24 @@ class TestHubspotStartDate(HubspotBaseTest):
                 start_date_1 = self.get_properties()['start_date']
                 start_date_2 = self.get_properties(original=False)['start_date']
 
-                # Verify by stream more records were replicated in the first sync, with an older start_date than the second
+                # Verify everthing in sync 2 is in sync 1
+                if first_sync_messages and second_sync_messages:
+                    first_sync_primary_keys = []
+                    sorted_pks = sorted(list(self.expected_metadata()[stream][self.PRIMARY_KEYS]))
+                    for message in first_sync_messages:
+                        record = message['data']
+                        primary_key = tuple([record[k] for k in sorted_pks])
+                        first_sync_primary_keys.append(primary_key)
+
+
+                    second_sync_primary_keys = []
+                    for message in second_sync_messages:
+                        record = message['data']
+                        primary_key = tuple([record[k] for k in sorted_pks])
+                        second_sync_primary_keys.append(primary_key)
+
+                    for pk in sorted(second_sync_primary_keys):
+                        self.assertIn(pk, first_sync_primary_keys)
+
+                # Verify the second sync has less data
                 self.assertGreaterEqual(first_sync_count, second_sync_count)

--- a/tests/test_hubspot_start_date_test.py
+++ b/tests/test_hubspot_start_date_test.py
@@ -26,7 +26,7 @@ class TestHubspotStartDate(HubspotBaseTest):
 
     def test_run(self):
         # SYNC 1
-        conn_id = self.ensure_connection()
+        conn_id = connections.ensure_connection()
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 
@@ -39,7 +39,7 @@ class TestHubspotStartDate(HubspotBaseTest):
         first_sync_records = runner.get_records_from_target_output()
 
         # SYNC 2
-        conn_id = self.ensure_connection(original=False)
+        conn_id = connections.ensure_connection(original_properties=False)
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
         catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]

--- a/tests/test_hubspot_start_date_test.py
+++ b/tests/test_hubspot_start_date_test.py
@@ -28,57 +28,32 @@ class TestHubspotStartDate(HubspotBaseTest):
         # SYNC 1
         conn_id = self.ensure_connection()
 
-        # Run in check mode
-        check_job_name = runner.run_check_mode(self, conn_id)
-
-        # Verify check exit codes
-        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
-        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
-
-        found_catalogs = menagerie.get_catalogs(conn_id)
-        self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
 
         # Select only the expected streams tables
         expected_streams = self.expected_streams()
         catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
         self.select_all_streams_and_fields(conn_id, catalog_entries)
 
-        # Run a sync job using orchestrator
-        sync_job_name = runner.run_sync_mode(self, conn_id)
+        first_record_count_by_stream = self.run_and_verify_sync(conn_id)
         first_sync_records = runner.get_records_from_target_output()
-        first_sync_record_count = runner.examine_target_output_file(
-            self, conn_id, self.expected_streams(), self.expected_primary_keys())
-
-        # Verify tap and target exit codes
-        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
-        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
 
         # SYNC 2
         conn_id = self.ensure_connection(original=False)
 
-        # Run in check mode
-        check_job_name = runner.run_check_mode(self, conn_id)
-
-        found_catalogs = menagerie.get_catalogs(conn_id)
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
         catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
         self.select_all_streams_and_fields(conn_id, catalog_entries)
 
-        # Run in Sync mode
-        sync_job_name = runner.run_sync_mode(self, conn_id)
+        second_record_count_by_stream = self.run_and_verify_sync(conn_id)
         second_sync_records = runner.get_records_from_target_output()
-        second_sync_record_count = runner.examine_target_output_file(
-            self, conn_id, self.expected_streams(), self.expected_primary_keys())
-
-        # Verify tap and target exit codes
-        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
-        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
 
         # Test by stream
         for stream in self.expected_streams():
             with self.subTest(stream=stream):
                 # record counts
-                first_sync_count = first_sync_record_count.get(stream, 0)
-                second_sync_count = second_sync_record_count.get(stream, 0)
+                first_sync_count = first_record_count_by_stream.get(stream, 0)
+                second_sync_count = second_record_count_by_stream.get(stream, 0)
 
                 # record messages
                 first_sync_messages = first_sync_records.get(stream, {'messages': []}).get('messages')

--- a/tests/test_hubspot_start_date_test.py
+++ b/tests/test_hubspot_start_date_test.py
@@ -105,22 +105,25 @@ class TestHubspotStartDate(HubspotBaseTest):
                 start_date_1 = self.get_properties()['start_date']
                 start_date_2 = self.get_properties(original=False)['start_date']
 
-                # Verify everthing in sync 2 is in sync 1
                 if first_sync_messages and second_sync_messages:
-                    first_sync_primary_keys = []
+
                     sorted_pks = sorted(list(self.expected_metadata()[stream][self.PRIMARY_KEYS]))
+
+                    # Get all primary keys for the first sync
+                    first_sync_primary_keys = []
                     for message in first_sync_messages:
                         record = message['data']
                         primary_key = tuple([record[k] for k in sorted_pks])
                         first_sync_primary_keys.append(primary_key)
 
-
+                    # Get all primary keys for the second sync
                     second_sync_primary_keys = []
                     for message in second_sync_messages:
                         record = message['data']
                         primary_key = tuple([record[k] for k in sorted_pks])
                         second_sync_primary_keys.append(primary_key)
 
+                    # Verify everthing in sync 2 is in sync 1
                     for pk in sorted(second_sync_primary_keys):
                         self.assertIn(pk, first_sync_primary_keys)
 

--- a/tests/test_hubspot_start_date_test.py
+++ b/tests/test_hubspot_start_date_test.py
@@ -26,7 +26,7 @@ class TestHubspotStartDate(HubspotBaseTest):
 
     def test_run(self):
         # SYNC 1
-        conn_id = connections.ensure_connection()
+        conn_id = connections.ensure_connection(self)
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 
@@ -39,7 +39,7 @@ class TestHubspotStartDate(HubspotBaseTest):
         first_sync_records = runner.get_records_from_target_output()
 
         # SYNC 2
-        conn_id = connections.ensure_connection(original_properties=False)
+        conn_id = connections.ensure_connection(self, original_properties=False)
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
         catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]

--- a/tests/test_hubspot_start_date_test.py
+++ b/tests/test_hubspot_start_date_test.py
@@ -8,23 +8,6 @@ class TestHubspotStartDate(HubspotBaseTest):
     def name(self):
         return "tap_tester_hubspot_combined_test"
 
-    def expected_check_streams(self):
-        return {
-            "subscription_changes",
-            "email_events",
-            "forms",
-            "workflows",
-            "owners",
-            "campaigns",
-            "contact_lists",
-            "contacts",
-            "companies",
-            "deals",
-            "engagements",
-            "deal_pipelines",
-            "contacts_by_company"
-        }
-
     def expected_streams(self):
         """All streams are under test"""
         return self.expected_check_streams() - {'subscription_changes', 'email_events'}

--- a/tests/unittests/test_deals.py
+++ b/tests/unittests/test_deals.py
@@ -36,14 +36,15 @@ class TestDeals(unittest.TestCase):
         params = {'count': 250,
                   'includeAssociations': False,
                   'properties' : []}
+        v3_fields = ['hs_date_entered_appointmentscheduled']
 
         records = list(
-            gen_request(state, 'deals', url, params, 'deals', "hasMore", ["offset"], ["offset"])
+            gen_request(state, 'deals', url, params, 'deals', "hasMore", ["offset"], ["offset"], v3_fields=v3_fields)
         )
 
         for record in records:
             # The test account has a deal stage called "appointment scheduled"
-            value = record.get('properties',{}).get('hs_date_entered_appointment_scheduled')
+            value = record.get('properties',{}).get('hs_date_entered_appointmentscheduled')
             error_msg = ('Could not find "hs_date_entered_appointment_scheduled"'
                          'in {}').format(record)
             self.assertIsNotNone(value, msg=error_msg)

--- a/tests/unittests/test_deals.py
+++ b/tests/unittests/test_deals.py
@@ -7,6 +7,7 @@ from tap_hubspot import acquire_access_token_from_refresh_token
 from tap_hubspot import CONFIG
 from tap_hubspot import gen_request
 from tap_hubspot import get_url
+from tap_hubspot import process_v3_deals_records
 
 
 class TestDeals(unittest.TestCase):
@@ -48,3 +49,21 @@ class TestDeals(unittest.TestCase):
             error_msg = ('Could not find "hs_date_entered_appointment_scheduled"'
                          'in {}').format(record)
             self.assertIsNotNone(value, msg=error_msg)
+
+    def test_process_v3_deals_records(self):
+        self.maxDiff = None
+        data = [
+            {'properties': {'field1': 'value1',
+                            'field2': 'value2',
+                            'hs_date_entered_field3': 'value3',
+                            'hs_date_exited_field4': 'value4',}},
+        ]
+
+        expected = [
+            {'properties': {'hs_date_entered_field3': {'value': 'value3'},
+                            'hs_date_exited_field4':  {'value': 'value4'},}},
+        ]
+
+        actual = process_v3_deals_records(data)
+
+        self.assertDictEqual(expected[0]['properties'], actual[0]['properties'])

--- a/tests/unittests/test_deals.py
+++ b/tests/unittests/test_deals.py
@@ -7,6 +7,7 @@ from tap_hubspot import acquire_access_token_from_refresh_token
 from tap_hubspot import CONFIG
 from tap_hubspot import gen_request
 from tap_hubspot import get_url
+from tap_hubspot import merge_responses
 from tap_hubspot import process_v3_deals_records
 
 
@@ -67,3 +68,34 @@ class TestDeals(unittest.TestCase):
         actual = process_v3_deals_records(data)
 
         self.assertDictEqual(expected[0]['properties'], actual[0]['properties'])
+
+    def test_merge_responses(self):
+        v1_resp = [
+            {'dealId': '1',
+             'properties': {'field1': 'value1',}},
+            {'dealId': '2',
+             'properties': {'field3': 'value3',}},
+        ]
+
+        v3_resp = [
+            {'id': '1',
+             'properties': {'field2': 'value2',}},
+            {'id': '2',
+             'properties': {'field4': 'value4',}},
+        ]
+
+        expected = [
+            {'dealId': '1',
+             'properties': {'field1': 'value1',
+                            'field2': 'value2',}},
+            {'dealId': '2',
+             'properties': {'field3': 'value3',
+                            'field4': 'value4',}},
+        ]
+
+        merge_responses(v1_resp, v3_resp)
+
+        for expected_record in expected:
+            for actual_record in v1_resp:
+                if actual_record['dealId'] == expected_record['dealId']:
+                    self.assertDictEqual(expected_record, actual_record)

--- a/tests/unittests/test_deals.py
+++ b/tests/unittests/test_deals.py
@@ -1,0 +1,49 @@
+"""
+Unit tests at the functions need to run `sync_deals`
+"""
+import os
+import unittest
+from tap_hubspot import acquire_access_token_from_refresh_token
+from tap_hubspot import CONFIG
+from tap_hubspot import gen_request
+from tap_hubspot import get_url
+
+
+class TestDeals(unittest.TestCase):
+    """
+    This class gets an access token for the tests to use and then tests
+    assumptions we have about the tap
+    """
+    def setUp(self):
+        """
+        This functions reads in the variables need to get an access token
+        """
+        CONFIG['redirect_uri'] = os.environ['HUBSPOT_REDIRECT_URI']
+        CONFIG['refresh_token'] = os.environ['HUBSPOT_REFRESH_TOKEN']
+        CONFIG['client_id'] = os.environ['HUBSPOT_CLIENT_ID']
+        CONFIG['client_secret'] = os.environ['HUBSPOT_CLIENT_SECRET']
+
+        acquire_access_token_from_refresh_token()
+
+
+    def test_can_fetch_hs_date_entered_props(self):
+        """
+        This test is written on the assumption that `sync_deals()` calls
+        `gen_request()` to get records
+        """
+        state = {}
+        url = get_url('deals_all')
+        params = {'count': 250,
+                  'includeAssociations': False,
+                  'properties' : []}
+
+        records = list(
+            gen_request(state, 'deals', url, params, 'deals', "hasMore", ["offset"], ["offset"])
+        )
+
+        for record in records:
+            # The test account has a deal stage called "appointment scheduled"
+            value = record.get('properties',{}).get('hs_date_entered_appointment_scheduled')
+            error_msg = ('Could not find "hs_date_entered_appointment_scheduled"'
+                         'in {}').format(record)
+            self.assertIsNotNone(value, msg=error_msg)


### PR DESCRIPTION
# Description of change
This PR hits the V3 Deals CRM API to get all `hs_date_entered_*` and `hs_date_exited_*` fields.

The "batch read" endpoint that Hubspot has lets us search for specific IDs. Given that V1 Deals and V3 Deals have the same primary key (`"dealId"` and `"id"` respectively) values, we can merge these new fields into the existing records

# Manual QA steps
- Ran the tap before and after the change to get records
- Diffed the two sets of records
 
# Risks
- Lower than #124. The main issue there is we did not paginate the V3 response and could not prove whether the first page of V1 records contains the same IDs as the first page of V3 records. But now that we are searching the V3 for explicit IDs we don't have to worry about that
 
# Rollback steps
 - revert this branch and bump the version
