### PR TITLE
Fix `500`s from V3 Deals

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -385,7 +385,7 @@ def get_v3_deals(v3_fields, v1_data):
     v1_ids = [{'id': str(record['dealId'])} for record in v1_data]
 
     v3_body = {'inputs': v1_ids,
-               'properties': v3_fields,}
+               'properties': list(v3_fields[0]),}
     v3_url = get_url('deals_v3_batch_read')
     v3_resp = post_search_endpoint(v3_url, v3_body)
     return v3_resp.json()['results']

--- a/tests/test_hubspot_all_fields_test.py
+++ b/tests/test_hubspot_all_fields_test.py
@@ -23,7 +23,29 @@ KNOWN_MISSING_FIELDS = {
         'property_hs_merged_object_ids',
         'property_hs_predicted_amount',
         'property_hs_predicted_amount_in_home_currency',
-        'property_hs_sales_email_last_replied'
+        'property_hs_sales_email_last_replied',
+        # These we have no data for
+        'property_hs_date_entered_appointmentscheduled',
+        'property_hs_date_entered_decisionmakerboughtin',
+        'property_hs_date_exited_qualifiedtobuy',
+        'property_hs_time_in_closedwon',
+        'property_hs_date_exited_appointmentscheduled',
+        'property_hs_time_in_decisionmakerboughtin',
+        'property_hs_date_exited_closedlost',
+        'property_hs_time_in_closedlost',
+        'property_hs_date_entered_closedlost',
+        'property_hs_date_entered_closedwon',
+        'property_hs_date_exited_contractsent',
+        'property_hs_time_in_presentationscheduled',
+        'property_hs_date_exited_presentationscheduled',
+        'property_hs_time_in_qualifiedtobuy',
+        'property_hs_date_exited_decisionmakerboughtin',
+        'property_hs_time_in_contractsent',
+        'property_hs_time_in_appointmentscheduled',
+        'property_hs_date_entered_presentationscheduled',
+        'property_hs_date_entered_qualifiedtobuy',
+        'property_hs_date_entered_contractsent',
+        'property_hs_date_exited_closedwon',
     },
 }
 
@@ -69,6 +91,7 @@ class TestHubspotAllFields(HubspotBaseTest):
                 print('Number of expected keys ', len(expected_fields))
                 actual_fields = set(runner.examine_target_output_for_fields()[stream])
                 print('Number of actual keys ', len(actual_fields))
+                print('Number of known missing keys ', len(KNOWN_MISSING_FIELDS[stream]))
 
                 unexpected_fields = actual_fields & KNOWN_MISSING_FIELDS[stream]
                 if unexpected_fields:


### PR DESCRIPTION
# Description of change
In order to get the extra fields from the V3 Deals API, we make a `POST` with (up to) 100 Deal `id`s and the `hs_date_entered_*`, `hs_date_exited_*`, and `hs_time_in_*` fields marked as selected.

The shape of this `POST` body is:
```
{
  "inputs" : [<deal ids>],
  "properties": [<fields>]
}
```

However, this `properties` list can get too long and Hubspot will return a `500`.

In testing, I noticed that:
* If you leave out the `properties` key, then some default set of fields is returned
* If you ask for any other field, then every non-null field on that deal is returned
* If you ask for a field that does not exist on the deal, then you get back `<key> : null`

Also in testing, I noticed that asking for more than 1000 properties may or may not return a `500`. But looking at the response (and this is dependent on the Hubspot account) most of the fields are null anyway. So we are asking for too much.

This PR reduces the "ask" down to just one field to leverage the second bullet above.

# Manual QA steps
- Ran the tap and confirmed we get a `500`
- Ran the tap, asking for 1000 fields, saved the records
- Ran the tap, asking for 1 field, saved the records
- Compared the two sets of records and noticed the fields are mostly the same
  - `hs_time_in_*` fields were slightly higher on the second set of records, but that makes sense as time has advanced
  - Only `hs_time_in_*` fields differed in my testing

 
# Risks
- Moderate. This is an undocumented feature of the API. Though, this is only an issue if you have a ton of deal stages
 
# Rollback steps
 - revert this branch
