### PR TITLE
added propertyMode:value_and_history to request so that properties_ve…

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -436,7 +436,7 @@ def _sync_contact_vids(catalog, vids, schema, bumble_bee):
     if len(vids) == 0:
         return
 
-    data = request(get_url("contacts_detail"), params={'vid': vids, 'showListMemberships' : True, "formSubmissionMode" : "all"}).json()
+    data = request(get_url("contacts_detail"), params={'vid': vids, 'showListMemberships' : True, "formSubmissionMode" : "all", "propertyMode": "value_and_history"}).json()
     time_extracted = utils.now()
     mdata = metadata.to_map(catalog.get('metadata'))
 


### PR DESCRIPTION
…rsions comes back on response

# Description of change
added propertyMode:value_and_history to request so that properties_versions comes back on response
# Manual QA steps
 - watched records come through
 
# Risks
 - a little risky, we saw slight differences in `list-memberships` field values when we added the parameter on the request
    - in one case, a subfield had a slightly different timestamp when we sent the record
    - in another case, a subfield was completely missing
 - ^ we determined there wasn't much we could do about this, hubspot just happened to be returned differently
 - ^ we will have to keep this in mind in case there are data discrepancies
 
# Rollback steps
 - revert this branch
