### PR TITLE
Send a list to the v3 batch read endpoint

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -384,8 +384,9 @@ def process_v3_deals_records(v3_data):
 def get_v3_deals(v3_fields, v1_data):
     v1_ids = [{'id': str(record['dealId'])} for record in v1_data]
 
+    # Sending the first v3_field is enough to get them all
     v3_body = {'inputs': v1_ids,
-               'properties': list(v3_fields[0]),}
+               'properties': [v3_fields[0]],}
     v3_url = get_url('deals_v3_batch_read')
     v3_resp = post_search_endpoint(v3_url, v3_body)
     return v3_resp.json()['results']


### PR DESCRIPTION
# Description of change

Fixes a bug where this was turning a string into `['h', 'e', 'l'. 'l'. 'o']`

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
