### PR TITLE
account for all_assigned_business_unit_ids in deals

### DIFF
--- a/tests/test_hubspot_all_fields_test.py
+++ b/tests/test_hubspot_all_fields_test.py
@@ -46,6 +46,7 @@ KNOWN_MISSING_FIELDS = {
         'property_hs_date_entered_qualifiedtobuy',
         'property_hs_date_entered_contractsent',
         'property_hs_date_exited_closedwon',
+        'property_hs_all_assigned_business_unit_ids',  # BUG https://stitchdata.atlassian.net/browse/SRCE-5063
     },
 }
 


### PR DESCRIPTION
# Description of change
New field was returned from deals endpoint.
Field was accounted for in test and carded out.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
