### PR TITLE
stitch validate json relative path instead of python 3.5 virtual env hardcoded path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json /usr/local/share/virtualenvs/tap-hubspot/lib/python3.5/site-packages/tap_hubspot/schemas/*.json
+            stitch-validate-json tap_hubspot/schemas/*.json
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/tests/test_hubspot_all_fields_test.py
+++ b/tests/test_hubspot_all_fields_test.py
@@ -46,7 +46,10 @@ KNOWN_MISSING_FIELDS = {
         'property_hs_date_entered_qualifiedtobuy',
         'property_hs_date_entered_contractsent',
         'property_hs_date_exited_closedwon',
-        'property_hs_all_assigned_business_unit_ids',  # BUG https://stitchdata.atlassian.net/browse/SRCE-5063
+        # BUG https://stitchdata.atlassian.net/browse/SRCE-5063
+        #     The following streams have been added since tests were written
+        'property_hs_all_assigned_business_unit_ids',
+        'property_hs_unique_creation_key',
     },
 }
 


### PR DESCRIPTION
# Description of change
stitch validate json relative path instead of python 3.5 virtual env hardcoded path

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
