### PR TITLE
Allow skipping of property extras and versions

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -4,5 +4,6 @@
   "client_secret": "my_secret",
   "refresh_token": "my_token",
   "start_date": "2017-01-01T00:00:00Z",
-  "disable_collection": false
+  "disable_collection": false,
+  "skip_property_extras_and_versions": false
 }

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -22,21 +22,27 @@ from singer import (transform,
 LOGGER = singer.get_logger()
 SESSION = requests.Session()
 
+
 class InvalidAuthException(Exception):
     pass
+
 
 class SourceUnavailableException(Exception):
     pass
 
+
 class DependencyException(Exception):
     pass
+
 
 class DataFields:
     offset = 'offset'
 
+
 class StateFields:
     offset = 'offset'
     this_stream = 'this_stream'
+
 
 BASE_URL = "https://api.hubapi.com"
 
@@ -51,6 +57,7 @@ CONFIG = {
     "token_expires": None,
     "email_chunk_size": DEFAULT_CHUNK_SIZE,
     "subscription_chunk_size": DEFAULT_CHUNK_SIZE,
+    "skip_property_extras_and_versions": False,
 
     # in config.json
     "redirect_uri": None,
@@ -97,17 +104,21 @@ ENDPOINTS = {
     "owners":               "/owners/v2/owners",
 }
 
+
 def get_start(state, tap_stream_id, bookmark_key):
     current_bookmark = singer.get_bookmark(state, tap_stream_id, bookmark_key)
     if current_bookmark is None:
         return CONFIG['start_date']
     return current_bookmark
 
+
 def get_current_sync_start(state, tap_stream_id):
-    current_sync_start_value = singer.get_bookmark(state, tap_stream_id, "current_sync_start")
+    current_sync_start_value = singer.get_bookmark(
+        state, tap_stream_id, "current_sync_start")
     if current_sync_start_value is None:
         return current_sync_start_value
     return utils.strptime_to_utc(current_sync_start_value)
+
 
 def write_current_sync_start(state, tap_stream_id, start):
     value = start
@@ -115,12 +126,15 @@ def write_current_sync_start(state, tap_stream_id, start):
         value = utils.strftime(start)
     return singer.write_bookmark(state, tap_stream_id, "current_sync_start", value)
 
+
 def clean_state(state):
     """ Clear deprecated keys out of state. """
     for stream, bookmark_map in state.get("bookmarks", {}).items():
         if "last_sync_duration" in bookmark_map:
-            LOGGER.info("{} - Removing last_sync_duration from state.".format(stream))
+            LOGGER.info(
+                "{} - Removing last_sync_duration from state.".format(stream))
             state["bookmarks"][stream].pop("last_sync_duration", None)
+
 
 def get_url(endpoint, **kwargs):
     if endpoint not in ENDPOINTS:
@@ -145,28 +159,34 @@ def get_field_type_schema(field_type):
     else:
         return {"type": ["null", "string"]}
 
+
 def get_field_schema(field_type, extras=False):
-    if extras:
-        return {
-            "type": "object",
-            "properties": {
-                "value": get_field_type_schema(field_type),
-                "timestamp": get_field_type_schema("datetime"),
-                "source": get_field_type_schema("string"),
-                "sourceId": get_field_type_schema("string"),
-            }
-        }
+    if CONFIG["skip_property_extras_and_versions"]:
+        return get_field_type_schema(field_type)
     else:
-        return {
-            "type": "object",
-            "properties": {
-                "value": get_field_type_schema(field_type),
+        if extras:
+            return {
+                "type": "object",
+                "properties": {
+                    "value": get_field_type_schema(field_type),
+                    "timestamp": get_field_type_schema("datetime"),
+                    "source": get_field_type_schema("string"),
+                    "sourceId": get_field_type_schema("string"),
+                }
             }
-        }
+        else:
+            return {
+                "type": "object",
+                "properties": {
+                    "value": get_field_type_schema(field_type),
+                }
+            }
+
 
 def parse_custom_schema(entity_name, data):
     return {
-        field['name']: get_field_schema(field['type'], entity_name != 'contacts')
+        field['name']: get_field_schema(
+            field['type'], entity_name != 'contacts')
         for field in data
     }
 
@@ -174,29 +194,36 @@ def parse_custom_schema(entity_name, data):
 def get_custom_schema(entity_name):
     return parse_custom_schema(entity_name, request(get_url(entity_name + "_properties")).json())
 
+
 def get_v3_schema(entity_name):
     url = get_url("deals_v3_properties")
     return parse_custom_schema(entity_name, request(url).json()['results'])
 
+
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
+
 
 def load_associated_company_schema():
     associated_company_schema = load_schema("companies")
     #pylint: disable=line-too-long
-    associated_company_schema['properties']['company-id'] = associated_company_schema['properties'].pop('companyId')
-    associated_company_schema['properties']['portal-id'] = associated_company_schema['properties'].pop('portalId')
+    associated_company_schema['properties']['company-id'] = associated_company_schema['properties'].pop(
+        'companyId')
+    associated_company_schema['properties']['portal-id'] = associated_company_schema['properties'].pop(
+        'portalId')
     return associated_company_schema
 
+
 def load_schema(entity_name):
-    schema = utils.load_json(get_abs_path('schemas/{}.json'.format(entity_name)))
+    schema = utils.load_json(get_abs_path(
+        'schemas/{}.json'.format(entity_name)))
     if entity_name in ["contacts", "companies", "deals"]:
         custom_schema = get_custom_schema(entity_name)
-
-        schema['properties']['properties'] = {
-            "type": "object",
-            "properties": custom_schema,
-        }
+        if not CONFIG["skip_property_extras_and_versions"]:
+            schema['properties']['properties'] = {
+                "type": "object",
+                "properties": custom_schema,
+            }
 
         if entity_name in ["deals"]:
             v3_schema = get_v3_schema(entity_name)
@@ -205,12 +232,15 @@ def load_schema(entity_name):
                     custom_schema[key] = value
 
         # Move properties to top level
-        custom_schema_top_level = {'property_{}'.format(k): v for k, v in custom_schema.items()}
+        custom_schema_top_level = {'property_{}'.format(
+            k): v for k, v in custom_schema.items()}
         schema['properties'].update(custom_schema_top_level)
 
         # Make properties_versions selectable and share the same schema.
-        versions_schema = utils.load_json(get_abs_path('schemas/versions.json'))
-        schema['properties']['properties_versions'] = versions_schema
+        if not CONFIG["skip_property_extras_and_versions"]:
+            versions_schema = utils.load_json(
+                get_abs_path('schemas/versions.json'))
+            schema['properties']['properties_versions'] = versions_schema
 
     if entity_name == "contacts":
         schema['properties']['associated-company'] = load_associated_company_schema()
@@ -218,6 +248,8 @@ def load_schema(entity_name):
     return schema
 
 #pylint: disable=invalid-name
+
+
 def acquire_access_token_from_refresh_token():
     payload = {
         "grant_type": "refresh_token",
@@ -226,7 +258,6 @@ def acquire_access_token_from_refresh_token():
         "client_id": CONFIG['client_id'],
         "client_secret": CONFIG['client_secret'],
     }
-
 
     resp = requests.post(BASE_URL + "/oauth/v1/token", data=payload)
     if resp.status_code == 403:
@@ -247,6 +278,7 @@ def giveup(exc):
         and 400 <= exc.response.status_code < 500 \
         and exc.response.status_code != 429
 
+
 def on_giveup(details):
     if len(details['args']) == 2:
         url, params = details['args']
@@ -254,16 +286,19 @@ def on_giveup(details):
         url = details['args']
         params = {}
 
-    raise Exception("Giving up on request after {} tries with url {} and params {}" \
+    raise Exception("Giving up on request after {} tries with url {} and params {}"
                     .format(details['tries'], url, params))
 
+
 URL_SOURCE_RE = re.compile(BASE_URL + r'/(\w+)/')
+
 
 def parse_source_from_url(url):
     match = URL_SOURCE_RE.match(url)
     if match:
         return match.group(1)
     return None
+
 
 def get_params_and_headers(params):
     """
@@ -300,7 +335,8 @@ def request(url, params=None):
 
     params, headers = get_params_and_headers(params)
 
-    req = requests.Request('GET', url, params=params, headers=headers).prepare()
+    req = requests.Request('GET', url, params=params,
+                           headers=headers).prepare()
     LOGGER.info("GET %s", req.url)
     with metrics.http_request_timer(parse_source_from_url(url)) as timer:
         resp = SESSION.send(req)
@@ -319,17 +355,24 @@ def request(url, params=None):
 # }
 # }
 
+
 def lift_properties_and_versions(record):
     for key, value in record.get('properties', {}).items():
         computed_key = "property_{}".format(key)
-        versions = value.get('versions')
-        record[computed_key] = value
+        if not CONFIG["skip_property_extras_and_versions"]:
+            versions = value.get('versions')
+            record[computed_key] = value
 
-        if versions:
-            if not record.get('properties_versions'):
-                record['properties_versions'] = []
-            record['properties_versions'] += versions
+            if versions:
+                if not record.get('properties_versions'):
+                    record['properties_versions'] = []
+                record['properties_versions'] += versions
+        else:
+            record[computed_key] = value.get('value')
+    if CONFIG["skip_property_extras_and_versions"]:
+        record.pop('properties', None)
     return record
+
 
 @backoff.on_exception(backoff.constant,
                       (requests.exceptions.RequestException,
@@ -356,6 +399,7 @@ def post_search_endpoint(url, data, params=None):
 
     return resp
 
+
 def merge_responses(v1_data, v3_data):
     for v1_record in v1_data:
         v1_id = v1_record.get('dealId')
@@ -364,6 +408,7 @@ def merge_responses(v1_data, v3_data):
             if str(v1_id) == v3_id:
                 v1_record['properties'] = {**v1_record['properties'],
                                            **v3_record['properties']}
+
 
 def process_v3_deals_records(v3_data):
     """
@@ -375,26 +420,30 @@ def process_v3_deals_records(v3_data):
     """
     transformed_v3_data = []
     for record in v3_data:
-        new_properties = {field_name : {'value': field_value}
+        new_properties = {field_name: {'value': field_value}
                           for field_name, field_value in record['properties'].items()
                           if any(prefix in field_name for prefix in V3_PREFIXES)}
-        transformed_v3_data.append({**record, 'properties' : new_properties})
+        transformed_v3_data.append({**record, 'properties': new_properties})
     return transformed_v3_data
+
 
 def get_v3_deals(v3_fields, v1_data):
     v1_ids = [{'id': str(record['dealId'])} for record in v1_data]
 
     # Sending the first v3_field is enough to get them all
     v3_body = {'inputs': v1_ids,
-               'properties': [v3_fields[0]],}
+               'properties': [v3_fields[0]], }
     v3_url = get_url('deals_v3_batch_read')
     v3_resp = post_search_endpoint(v3_url, v3_body)
     return v3_resp.json()['results']
 
 #pylint: disable=line-too-long
+
+
 def gen_request(STATE, tap_stream_id, url, params, path, more_key, offset_keys, offset_targets, v3_fields=None):
     if len(offset_keys) != len(offset_targets):
-        raise ValueError("Number of offset_keys must match number of offset_targets")
+        raise ValueError(
+            "Number of offset_keys must match number of offset_targets")
 
     if singer.get_offset(STATE, tap_stream_id):
         params.update(singer.get_offset(STATE, tap_stream_id))
@@ -404,7 +453,8 @@ def gen_request(STATE, tap_stream_id, url, params, path, more_key, offset_keys, 
             data = request(url, params).json()
 
             if data.get(path) is None:
-                raise RuntimeError("Unexpected API response: {} not in {}".format(path, data.keys()))
+                raise RuntimeError(
+                    "Unexpected API response: {} not in {}".format(path, data.keys()))
 
             if v3_fields:
                 v3_data = get_v3_deals(v3_fields, data[path])
@@ -425,7 +475,8 @@ def gen_request(STATE, tap_stream_id, url, params, path, more_key, offset_keys, 
             for key, target in zip(offset_keys, offset_targets):
                 if key in data:
                     params[target] = data[key]
-                    STATE = singer.set_offset(STATE, tap_stream_id, target, data[key])
+                    STATE = singer.set_offset(
+                        STATE, tap_stream_id, target, data[key])
 
             singer.write_state(STATE)
 
@@ -437,19 +488,24 @@ def _sync_contact_vids(catalog, vids, schema, bumble_bee):
     if len(vids) == 0:
         return
 
-    data = request(get_url("contacts_detail"), params={'vid': vids, 'showListMemberships' : True, "formSubmissionMode" : "all"}).json()
+    data = request(get_url("contacts_detail"), params={
+                   'vid': vids, 'showListMemberships': True, "formSubmissionMode": "all"}).json()
     time_extracted = utils.now()
     mdata = metadata.to_map(catalog.get('metadata'))
 
     for record in data.values():
-        record = bumble_bee.transform(lift_properties_and_versions(record), schema, mdata)
-        singer.write_record("contacts", record, catalog.get('stream_alias'), time_extracted=time_extracted)
+        record = bumble_bee.transform(
+            lift_properties_and_versions(record), schema, mdata)
+        singer.write_record("contacts", record, catalog.get(
+            'stream_alias'), time_extracted=time_extracted)
+
 
 default_contact_params = {
     'showListMemberships': True,
     'includeVersion': True,
     'count': 100,
 }
+
 
 def sync_contacts(STATE, ctx):
     catalog = ctx.get_catalog_from_id(singer.get_currently_syncing(STATE))
@@ -460,7 +516,8 @@ def sync_contacts(STATE, ctx):
     max_bk_value = start
     schema = load_schema("contacts")
 
-    singer.write_schema("contacts", schema, ["vid"], [bookmark_key], catalog.get('stream_alias'))
+    singer.write_schema("contacts", schema, ["vid"], [
+                        bookmark_key], catalog.get('stream_alias'))
 
     url = get_url("contacts_all")
 
@@ -470,7 +527,7 @@ def sync_contacts(STATE, ctx):
             modified_time = None
             if bookmark_key in row:
                 modified_time = utils.strptime_with_tz(
-                    _transform_datetime( # pylint: disable=protected-access
+                    _transform_datetime(  # pylint: disable=protected-access
                         row[bookmark_key],
                         UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING))
 
@@ -486,21 +543,28 @@ def sync_contacts(STATE, ctx):
 
         _sync_contact_vids(catalog, vids, schema, bumble_bee)
 
-    STATE = singer.write_bookmark(STATE, 'contacts', bookmark_key, utils.strftime(max_bk_value))
+    STATE = singer.write_bookmark(
+        STATE, 'contacts', bookmark_key, utils.strftime(max_bk_value))
     singer.write_state(STATE)
     return STATE
+
 
 class ValidationPredFailed(Exception):
     pass
 
 # companies_recent only supports 10,000 results. If there are more than this,
 # we'll need to use the companies_all endpoint
+
+
 def use_recent_companies_endpoint(response):
     return response["total"] < 10000
 
-default_contacts_by_company_params = {'count' : 100}
+
+default_contacts_by_company_params = {'count': 100}
 
 # NB> to do: support stream aliasing and field selection
+
+
 def _sync_contacts_by_company(STATE, ctx, company_id):
     schema = load_schema(CONTACTS_BY_COMPANY)
     catalog = ctx.get_catalog_from_id(singer.get_currently_syncing(STATE))
@@ -512,20 +576,25 @@ def _sync_contacts_by_company(STATE, ctx, company_id):
             data = request(url, default_contacts_by_company_params).json()
 
             if data.get(path) is None:
-                raise RuntimeError("Unexpected API response: {} not in {}".format(path, data.keys()))
+                raise RuntimeError(
+                    "Unexpected API response: {} not in {}".format(path, data.keys()))
 
             for row in data[path]:
                 counter.increment()
-                record = {'company-id' : company_id,
-                          'contact-id' : row}
-                record = bumble_bee.transform(lift_properties_and_versions(record), schema, mdata)
-                singer.write_record("contacts_by_company", record, time_extracted=utils.now())
+                record = {'company-id': company_id,
+                          'contact-id': row}
+                record = bumble_bee.transform(
+                    lift_properties_and_versions(record), schema, mdata)
+                singer.write_record("contacts_by_company",
+                                    record, time_extracted=utils.now())
 
     return STATE
+
 
 default_company_params = {
     'limit': 250, 'properties': ["createdate", "hs_lastmodifieddate"]
 }
+
 
 def sync_companies(STATE, ctx):
     catalog = ctx.get_catalog_from_id(singer.get_currently_syncing(STATE))
@@ -535,7 +604,8 @@ def sync_companies(STATE, ctx):
     start = utils.strptime_to_utc(get_start(STATE, "companies", bookmark_key))
     LOGGER.info("sync_companies from %s", start)
     schema = load_schema('companies')
-    singer.write_schema("companies", schema, ["companyId"], [bookmark_key], catalog.get('stream_alias'))
+    singer.write_schema("companies", schema, ["companyId"], [
+                        bookmark_key], catalog.get('stream_alias'))
 
     # Because this stream doesn't query by `lastUpdated`, it cycles
     # through the data set every time. The issue with this is that there
@@ -543,7 +613,8 @@ def sync_companies(STATE, ctx):
     # start of this table's sync and the end, causing some updates to not
     # be captured, in order to combat this, we must store the current
     # sync's start in the state and not move the bookmark past this value.
-    current_sync_start = get_current_sync_start(STATE, "companies") or utils.now()
+    current_sync_start = get_current_sync_start(
+        STATE, "companies") or utils.now()
     STATE = write_current_sync_start(STATE, "companies", current_sync_start)
     singer.write_state(STATE)
 
@@ -551,7 +622,8 @@ def sync_companies(STATE, ctx):
     max_bk_value = start
     if CONTACTS_BY_COMPANY in ctx.selected_stream_ids:
         contacts_by_company_schema = load_schema(CONTACTS_BY_COMPANY)
-        singer.write_schema("contacts_by_company", contacts_by_company_schema, ["company-id", "contact-id"])
+        singer.write_schema("contacts_by_company", contacts_by_company_schema, [
+                            "company-id", "contact-id"])
 
     with bumble_bee:
         for row in gen_request(STATE, 'companies', url, default_company_params, 'companies', 'has-more', ['offset'], ['offset']):
@@ -560,35 +632,45 @@ def sync_companies(STATE, ctx):
             if bookmark_key in row_properties:
                 # Hubspot returns timestamps in millis
                 timestamp_millis = row_properties[bookmark_key]['timestamp'] / 1000.0
-                modified_time = datetime.datetime.fromtimestamp(timestamp_millis, datetime.timezone.utc)
+                modified_time = datetime.datetime.fromtimestamp(
+                    timestamp_millis, datetime.timezone.utc)
             elif 'createdate' in row_properties:
                 # Hubspot returns timestamps in millis
                 timestamp_millis = row_properties['createdate']['timestamp'] / 1000.0
-                modified_time = datetime.datetime.fromtimestamp(timestamp_millis, datetime.timezone.utc)
+                modified_time = datetime.datetime.fromtimestamp(
+                    timestamp_millis, datetime.timezone.utc)
 
             if modified_time and modified_time >= max_bk_value:
                 max_bk_value = modified_time
 
             if not modified_time or modified_time >= start:
-                record = request(get_url("companies_detail", company_id=row['companyId'])).json()
-                record = bumble_bee.transform(lift_properties_and_versions(record), schema, mdata)
-                singer.write_record("companies", record, catalog.get('stream_alias'), time_extracted=utils.now())
+                record = request(get_url("companies_detail",
+                                         company_id=row['companyId'])).json()
+                record = bumble_bee.transform(
+                    lift_properties_and_versions(record), schema, mdata)
+                singer.write_record("companies", record, catalog.get(
+                    'stream_alias'), time_extracted=utils.now())
                 if CONTACTS_BY_COMPANY in ctx.selected_stream_ids:
-                    STATE = _sync_contacts_by_company(STATE, ctx, record['companyId'])
+                    STATE = _sync_contacts_by_company(
+                        STATE, ctx, record['companyId'])
 
     # Don't bookmark past the start of this sync to account for updated records during the sync.
     new_bookmark = min(max_bk_value, current_sync_start)
-    STATE = singer.write_bookmark(STATE, 'companies', bookmark_key, utils.strftime(new_bookmark))
+    STATE = singer.write_bookmark(
+        STATE, 'companies', bookmark_key, utils.strftime(new_bookmark))
     STATE = write_current_sync_start(STATE, 'companies', None)
     singer.write_state(STATE)
     return STATE
 
+
 def has_selected_custom_field(mdata):
-    top_level_custom_props = [x for x in mdata if len(x) == 2 and 'property_' in x[1]]
+    top_level_custom_props = [
+        x for x in mdata if len(x) == 2 and 'property_' in x[1]]
     for prop in top_level_custom_props:
         if mdata.get(prop, {}).get('selected') == True:
             return True
     return False
+
 
 def sync_deals(STATE, ctx):
     catalog = ctx.get_catalog_from_id(singer.get_currently_syncing(STATE))
@@ -600,10 +682,11 @@ def sync_deals(STATE, ctx):
     most_recent_modified_time = start
     params = {'limit': 100,
               'includeAssociations': False,
-              'properties' : []}
+              'properties': []}
 
     schema = load_schema("deals")
-    singer.write_schema("deals", schema, ["dealId"], [bookmark_key], catalog.get('stream_alias'))
+    singer.write_schema("deals", schema, ["dealId"], [
+                        bookmark_key], catalog.get('stream_alias'))
 
     # Check if we should  include associations
     for key in mdata.keys():
@@ -613,7 +696,8 @@ def sync_deals(STATE, ctx):
                 params['includeAssociations'] = True
 
     v3_fields = None
-    has_selected_properties = mdata.get(('properties', 'properties'), {}).get('selected')
+    has_selected_properties = mdata.get(
+        ('properties', 'properties'), {}).get('selected')
     if has_selected_properties or has_selected_custom_field(mdata):
         # On 2/12/20, hubspot added a lot of additional properties for
         # deals, and appending all of them to requests ended up leading to
@@ -638,37 +722,48 @@ def sync_deals(STATE, ctx):
             if bookmark_key in row_properties:
                 # Hubspot returns timestamps in millis
                 timestamp_millis = row_properties[bookmark_key]['timestamp'] / 1000.0
-                modified_time = datetime.datetime.fromtimestamp(timestamp_millis, datetime.timezone.utc)
+                modified_time = datetime.datetime.fromtimestamp(
+                    timestamp_millis, datetime.timezone.utc)
             elif 'createdate' in row_properties:
                 # Hubspot returns timestamps in millis
                 timestamp_millis = row_properties['createdate']['timestamp'] / 1000.0
-                modified_time = datetime.datetime.fromtimestamp(timestamp_millis, datetime.timezone.utc)
+                modified_time = datetime.datetime.fromtimestamp(
+                    timestamp_millis, datetime.timezone.utc)
             if modified_time and modified_time >= max_bk_value:
                 max_bk_value = modified_time
 
             if not modified_time or modified_time >= start:
-                record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
-                singer.write_record("deals", record, catalog.get('stream_alias'), time_extracted=utils.now())
+                record = bumble_bee.transform(
+                    lift_properties_and_versions(row), schema, mdata)
+                singer.write_record("deals", record, catalog.get(
+                    'stream_alias'), time_extracted=utils.now())
 
-    STATE = singer.write_bookmark(STATE, 'deals', bookmark_key, utils.strftime(max_bk_value))
+    STATE = singer.write_bookmark(
+        STATE, 'deals', bookmark_key, utils.strftime(max_bk_value))
     singer.write_state(STATE)
     return STATE
 
-#NB> no suitable bookmark is available: https://developers.hubspot.com/docs/methods/email/get_campaigns_by_id
+# NB> no suitable bookmark is available: https://developers.hubspot.com/docs/methods/email/get_campaigns_by_id
+
+
 def sync_campaigns(STATE, ctx):
     catalog = ctx.get_catalog_from_id(singer.get_currently_syncing(STATE))
     mdata = metadata.to_map(catalog.get('metadata'))
     schema = load_schema("campaigns")
-    singer.write_schema("campaigns", schema, ["id"], catalog.get('stream_alias'))
+    singer.write_schema("campaigns", schema, [
+                        "id"], catalog.get('stream_alias'))
     LOGGER.info("sync_campaigns(NO bookmarks)")
     url = get_url("campaigns_all")
     params = {'limit': 500}
 
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
         for row in gen_request(STATE, 'campaigns', url, params, "campaigns", "hasMore", ["offset"], ["offset"]):
-            record = request(get_url("campaigns_detail", campaign_id=row['id'])).json()
-            record = bumble_bee.transform(lift_properties_and_versions(record), schema, mdata)
-            singer.write_record("campaigns", record, catalog.get('stream_alias'), time_extracted=utils.now())
+            record = request(get_url("campaigns_detail",
+                                     campaign_id=row['id'])).json()
+            record = bumble_bee.transform(
+                lift_properties_and_versions(record), schema, mdata)
+            singer.write_record("campaigns", record, catalog.get(
+                'stream_alias'), time_extracted=utils.now())
 
     return STATE
 
@@ -677,7 +772,8 @@ def sync_entity_chunked(STATE, catalog, entity_name, key_properties, path):
     schema = load_schema(entity_name)
     bookmark_key = 'startTimestamp'
 
-    singer.write_schema(entity_name, schema, key_properties, [bookmark_key], catalog.get('stream_alias'))
+    singer.write_schema(entity_name, schema, key_properties, [
+                        bookmark_key], catalog.get('stream_alias'))
 
     start = get_start(STATE, entity_name, bookmark_key)
     LOGGER.info("sync_%s from %s", entity_name, start)
@@ -713,23 +809,27 @@ def sync_entity_chunked(STATE, catalog, entity_name, key_properties, path):
                     time_extracted = utils.now()
 
                     if data.get(path) is None:
-                        raise RuntimeError("Unexpected API response: {} not in {}".format(path, data.keys()))
+                        raise RuntimeError(
+                            "Unexpected API response: {} not in {}".format(path, data.keys()))
 
                     for row in data[path]:
                         counter.increment()
-                        record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
+                        record = bumble_bee.transform(
+                            lift_properties_and_versions(row), schema, mdata)
                         singer.write_record(entity_name,
                                             record,
                                             catalog.get('stream_alias'),
                                             time_extracted=time_extracted)
                     if data.get('hasMore'):
-                        STATE = singer.set_offset(STATE, entity_name, 'offset', data['offset'])
+                        STATE = singer.set_offset(
+                            STATE, entity_name, 'offset', data['offset'])
                         singer.write_state(STATE)
                     else:
                         STATE = singer.clear_offset(STATE, entity_name)
                         singer.write_state(STATE)
                         break
-            STATE = singer.write_bookmark(STATE, entity_name, 'startTimestamp', utils.strftime(datetime.datetime.fromtimestamp((start_ts / 1000), datetime.timezone.utc ))) # pylint: disable=line-too-long
+            STATE = singer.write_bookmark(STATE, entity_name, 'startTimestamp', utils.strftime(
+                datetime.datetime.fromtimestamp((start_ts / 1000), datetime.timezone.utc)))  # pylint: disable=line-too-long
             singer.write_state(STATE)
             start_ts = end_ts
 
@@ -737,23 +837,28 @@ def sync_entity_chunked(STATE, catalog, entity_name, key_properties, path):
     singer.write_state(STATE)
     return STATE
 
+
 def sync_subscription_changes(STATE, ctx):
     catalog = ctx.get_catalog_from_id(singer.get_currently_syncing(STATE))
     STATE = sync_entity_chunked(STATE, catalog, "subscription_changes", ["timestamp", "portalId", "recipient"],
                                 "timeline")
     return STATE
 
+
 def sync_email_events(STATE, ctx):
     catalog = ctx.get_catalog_from_id(singer.get_currently_syncing(STATE))
-    STATE = sync_entity_chunked(STATE, catalog, "email_events", ["id"], "events")
+    STATE = sync_entity_chunked(
+        STATE, catalog, "email_events", ["id"], "events")
     return STATE
+
 
 def sync_contact_lists(STATE, ctx):
     catalog = ctx.get_catalog_from_id(singer.get_currently_syncing(STATE))
     mdata = metadata.to_map(catalog.get('metadata'))
     schema = load_schema("contact_lists")
     bookmark_key = 'updatedAt'
-    singer.write_schema("contact_lists", schema, ["listId"], [bookmark_key], catalog.get('stream_alias'))
+    singer.write_schema("contact_lists", schema, ["listId"], [
+                        bookmark_key], catalog.get('stream_alias'))
 
     start = get_start(STATE, "contact_lists", bookmark_key)
     max_bk_value = start
@@ -764,17 +869,21 @@ def sync_contact_lists(STATE, ctx):
     params = {'count': 250}
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
         for row in gen_request(STATE, 'contact_lists', url, params, "lists", "has-more", ["offset"], ["offset"]):
-            record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
+            record = bumble_bee.transform(
+                lift_properties_and_versions(row), schema, mdata)
 
             if record[bookmark_key] >= start:
-                singer.write_record("contact_lists", record, catalog.get('stream_alias'), time_extracted=utils.now())
+                singer.write_record("contact_lists", record, catalog.get(
+                    'stream_alias'), time_extracted=utils.now())
             if record[bookmark_key] >= max_bk_value:
                 max_bk_value = record[bookmark_key]
 
-    STATE = singer.write_bookmark(STATE, 'contact_lists', bookmark_key, max_bk_value)
+    STATE = singer.write_bookmark(
+        STATE, 'contact_lists', bookmark_key, max_bk_value)
     singer.write_state(STATE)
 
     return STATE
+
 
 def sync_forms(STATE, ctx):
     catalog = ctx.get_catalog_from_id(singer.get_currently_syncing(STATE))
@@ -782,7 +891,8 @@ def sync_forms(STATE, ctx):
     schema = load_schema("forms")
     bookmark_key = 'updatedAt'
 
-    singer.write_schema("forms", schema, ["guid"], [bookmark_key], catalog.get('stream_alias'))
+    singer.write_schema("forms", schema, ["guid"], [
+                        bookmark_key], catalog.get('stream_alias'))
     start = get_start(STATE, "forms", bookmark_key)
     max_bk_value = start
 
@@ -793,10 +903,12 @@ def sync_forms(STATE, ctx):
 
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
         for row in data:
-            record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
+            record = bumble_bee.transform(
+                lift_properties_and_versions(row), schema, mdata)
 
             if record[bookmark_key] >= start:
-                singer.write_record("forms", record, catalog.get('stream_alias'), time_extracted=time_extracted)
+                singer.write_record("forms", record, catalog.get(
+                    'stream_alias'), time_extracted=time_extracted)
             if record[bookmark_key] >= max_bk_value:
                 max_bk_value = record[bookmark_key]
 
@@ -805,16 +917,19 @@ def sync_forms(STATE, ctx):
 
     return STATE
 
+
 def sync_workflows(STATE, ctx):
     catalog = ctx.get_catalog_from_id(singer.get_currently_syncing(STATE))
     mdata = metadata.to_map(catalog.get('metadata'))
     schema = load_schema("workflows")
     bookmark_key = 'updatedAt'
-    singer.write_schema("workflows", schema, ["id"], [bookmark_key], catalog.get('stream_alias'))
+    singer.write_schema("workflows", schema, ["id"], [
+                        bookmark_key], catalog.get('stream_alias'))
     start = get_start(STATE, "workflows", bookmark_key)
     max_bk_value = start
 
-    STATE = singer.write_bookmark(STATE, 'workflows', bookmark_key, max_bk_value)
+    STATE = singer.write_bookmark(
+        STATE, 'workflows', bookmark_key, max_bk_value)
     singer.write_state(STATE)
 
     LOGGER.info("sync_workflows from %s", start)
@@ -824,15 +939,19 @@ def sync_workflows(STATE, ctx):
 
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
         for row in data['workflows']:
-            record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
+            record = bumble_bee.transform(
+                lift_properties_and_versions(row), schema, mdata)
             if record[bookmark_key] >= start:
-                singer.write_record("workflows", record, catalog.get('stream_alias'), time_extracted=time_extracted)
+                singer.write_record("workflows", record, catalog.get(
+                    'stream_alias'), time_extracted=time_extracted)
             if record[bookmark_key] >= max_bk_value:
                 max_bk_value = record[bookmark_key]
 
-    STATE = singer.write_bookmark(STATE, 'workflows', bookmark_key, max_bk_value)
+    STATE = singer.write_bookmark(
+        STATE, 'workflows', bookmark_key, max_bk_value)
     singer.write_state(STATE)
     return STATE
+
 
 def sync_owners(STATE, ctx):
     catalog = ctx.get_catalog_from_id(singer.get_currently_syncing(STATE))
@@ -840,7 +959,8 @@ def sync_owners(STATE, ctx):
     schema = load_schema("owners")
     bookmark_key = 'updatedAt'
 
-    singer.write_schema("owners", schema, ["ownerId"], [bookmark_key], catalog.get('stream_alias'))
+    singer.write_schema("owners", schema, ["ownerId"], [
+                        bookmark_key], catalog.get('stream_alias'))
     start = get_start(STATE, "owners", bookmark_key)
     max_bk_value = start
 
@@ -855,23 +975,27 @@ def sync_owners(STATE, ctx):
 
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
         for row in data:
-            record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
+            record = bumble_bee.transform(
+                lift_properties_and_versions(row), schema, mdata)
             if record[bookmark_key] >= max_bk_value:
                 max_bk_value = record[bookmark_key]
 
             if record[bookmark_key] >= start:
-                singer.write_record("owners", record, catalog.get('stream_alias'), time_extracted=time_extracted)
+                singer.write_record("owners", record, catalog.get(
+                    'stream_alias'), time_extracted=time_extracted)
 
     STATE = singer.write_bookmark(STATE, 'owners', bookmark_key, max_bk_value)
     singer.write_state(STATE)
     return STATE
+
 
 def sync_engagements(STATE, ctx):
     catalog = ctx.get_catalog_from_id(singer.get_currently_syncing(STATE))
     mdata = metadata.to_map(catalog.get('metadata'))
     schema = load_schema("engagements")
     bookmark_key = 'lastUpdated'
-    singer.write_schema("engagements", schema, ["engagement_id"], [bookmark_key], catalog.get('stream_alias'))
+    singer.write_schema("engagements", schema, ["engagement_id"], [
+                        bookmark_key], catalog.get('stream_alias'))
     start = get_start(STATE, "engagements", bookmark_key)
 
     # Because this stream doesn't query by `lastUpdated`, it cycles
@@ -880,7 +1004,8 @@ def sync_engagements(STATE, ctx):
     # start of this table's sync and the end, causing some updates to not
     # be captured, in order to combat this, we must store the current
     # sync's start in the state and not move the bookmark past this value.
-    current_sync_start = get_current_sync_start(STATE, "engagements") or utils.now()
+    current_sync_start = get_current_sync_start(
+        STATE, "engagements") or utils.now()
     STATE = write_current_sync_start(STATE, "engagements", current_sync_start)
     singer.write_state(STATE)
 
@@ -893,41 +1018,50 @@ def sync_engagements(STATE, ctx):
     url = get_url("engagements_all")
     params = {'limit': 250}
     top_level_key = "results"
-    engagements = gen_request(STATE, 'engagements', url, params, top_level_key, "hasMore", ["offset"], ["offset"])
+    engagements = gen_request(STATE, 'engagements', url, params,
+                              top_level_key, "hasMore", ["offset"], ["offset"])
 
     time_extracted = utils.now()
 
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
         for engagement in engagements:
-            record = bumble_bee.transform(lift_properties_and_versions(engagement), schema, mdata)
+            record = bumble_bee.transform(
+                lift_properties_and_versions(engagement), schema, mdata)
             if record['engagement'][bookmark_key] >= start:
                 # hoist PK and bookmark field to top-level record
                 record['engagement_id'] = record['engagement']['id']
                 record[bookmark_key] = record['engagement'][bookmark_key]
-                singer.write_record("engagements", record, catalog.get('stream_alias'), time_extracted=time_extracted)
+                singer.write_record("engagements", record, catalog.get(
+                    'stream_alias'), time_extracted=time_extracted)
                 if record['engagement'][bookmark_key] >= max_bk_value:
                     max_bk_value = record['engagement'][bookmark_key]
 
     # Don't bookmark past the start of this sync to account for updated records during the sync.
     new_bookmark = min(utils.strptime_to_utc(max_bk_value), current_sync_start)
-    STATE = singer.write_bookmark(STATE, 'engagements', bookmark_key, utils.strftime(new_bookmark))
+    STATE = singer.write_bookmark(
+        STATE, 'engagements', bookmark_key, utils.strftime(new_bookmark))
     STATE = write_current_sync_start(STATE, 'engagements', None)
     singer.write_state(STATE)
     return STATE
+
 
 def sync_deal_pipelines(STATE, ctx):
     catalog = ctx.get_catalog_from_id(singer.get_currently_syncing(STATE))
     mdata = metadata.to_map(catalog.get('metadata'))
     schema = load_schema('deal_pipelines')
-    singer.write_schema('deal_pipelines', schema, ['pipelineId'], catalog.get('stream_alias'))
+    singer.write_schema('deal_pipelines', schema, [
+                        'pipelineId'], catalog.get('stream_alias'))
     LOGGER.info('sync_deal_pipelines')
     data = request(get_url('deal_pipelines')).json()
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
         for row in data:
-            record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
-            singer.write_record("deal_pipelines", record, catalog.get('stream_alias'), time_extracted=utils.now())
+            record = bumble_bee.transform(
+                lift_properties_and_versions(row), schema, mdata)
+            singer.write_record("deal_pipelines", record, catalog.get(
+                'stream_alias'), time_extracted=utils.now())
     singer.write_state(STATE)
     return STATE
+
 
 @attr.s
 class Stream(object):
@@ -937,23 +1071,33 @@ class Stream(object):
     replication_key = attr.ib()
     replication_method = attr.ib()
 
+
 STREAMS = [
     # Do these first as they are incremental
-    Stream('subscription_changes', sync_subscription_changes, ['timestamp', 'portalId', 'recipient'], 'startTimestamp', 'INCREMENTAL'),
-    Stream('email_events', sync_email_events, ['id'], 'startTimestamp', 'INCREMENTAL'),
+    Stream('subscription_changes', sync_subscription_changes, [
+           'timestamp', 'portalId', 'recipient'], 'startTimestamp', 'INCREMENTAL'),
+    Stream('email_events', sync_email_events, [
+           'id'], 'startTimestamp', 'INCREMENTAL'),
 
     # Do these last as they are full table
     Stream('forms', sync_forms, ['guid'], 'updatedAt', 'FULL_TABLE'),
     Stream('workflows', sync_workflows, ['id'], 'updatedAt', 'FULL_TABLE'),
     Stream('owners', sync_owners, ["ownerId"], 'updatedAt', 'FULL_TABLE'),
     Stream('campaigns', sync_campaigns, ["id"], None, 'FULL_TABLE'),
-    Stream('contact_lists', sync_contact_lists, ["listId"], 'updatedAt', 'FULL_TABLE'),
-    Stream('contacts', sync_contacts, ["vid"], 'versionTimestamp', 'FULL_TABLE'),
-    Stream('companies', sync_companies, ["companyId"], 'hs_lastmodifieddate', 'FULL_TABLE'),
-    Stream('deals', sync_deals, ["dealId"], 'hs_lastmodifieddate', 'FULL_TABLE'),
-    Stream('deal_pipelines', sync_deal_pipelines, ['pipelineId'], None, 'FULL_TABLE'),
-    Stream('engagements', sync_engagements, ["engagement_id"], 'lastUpdated', 'FULL_TABLE')
+    Stream('contact_lists', sync_contact_lists, [
+           "listId"], 'updatedAt', 'FULL_TABLE'),
+    Stream('contacts', sync_contacts, ["vid"],
+           'versionTimestamp', 'FULL_TABLE'),
+    Stream('companies', sync_companies, [
+           "companyId"], 'hs_lastmodifieddate', 'FULL_TABLE'),
+    Stream('deals', sync_deals, ["dealId"],
+           'hs_lastmodifieddate', 'FULL_TABLE'),
+    Stream('deal_pipelines', sync_deal_pipelines,
+           ['pipelineId'], None, 'FULL_TABLE'),
+    Stream('engagements', sync_engagements, [
+           "engagement_id"], 'lastUpdated', 'FULL_TABLE')
 ]
+
 
 def get_streams_to_sync(streams, state):
     target_stream = singer.get_currently_syncing(state)
@@ -963,10 +1107,11 @@ def get_streams_to_sync(streams, state):
             lambda x: x.tap_stream_id != target_stream, streams))
         rest = list(itertools.dropwhile(
             lambda x: x.tap_stream_id != target_stream, streams))
-        result = rest + skipped # Move skipped streams to end
+        result = rest + skipped  # Move skipped streams to end
     if not result:
         raise Exception('Unknown stream {} in state'.format(target_stream))
     return result
+
 
 def get_selected_streams(remaining_streams, ctx):
     selected_streams = []
@@ -974,6 +1119,7 @@ def get_selected_streams(remaining_streams, ctx):
         if stream.tap_stream_id in ctx.selected_stream_ids:
             selected_streams.append(stream)
     return selected_streams
+
 
 def do_sync(STATE, catalog):
     # Clear out keys that are no longer used
@@ -992,7 +1138,7 @@ def do_sync(STATE, catalog):
         singer.write_state(STATE)
 
         try:
-            STATE = stream.sync(STATE, ctx) # pylint: disable=not-callable
+            STATE = stream.sync(STATE, ctx)  # pylint: disable=not-callable
         except SourceUnavailableException as ex:
             error_message = str(ex).replace(CONFIG['access_token'], 10 * '*')
             LOGGER.error(error_message)
@@ -1001,6 +1147,7 @@ def do_sync(STATE, catalog):
     STATE = singer.set_currently_syncing(STATE, None)
     singer.write_state(STATE)
     LOGGER.info("Sync completed")
+
 
 class Context(object):
     def __init__(self, catalog):
@@ -1013,48 +1160,59 @@ class Context(object):
 
         self.catalog = catalog
 
-    def get_catalog_from_id(self,tap_stream_id):
+    def get_catalog_from_id(self, tap_stream_id):
         return [c for c in self.catalog.get('streams')
-               if c.get('stream') == tap_stream_id][0]
+                if c.get('stream') == tap_stream_id][0]
+
 
 # stream a is dependent on stream STREAM_DEPENDENCIES[a]
 STREAM_DEPENDENCIES = {
     CONTACTS_BY_COMPANY: 'companies'
 }
 
+
 def validate_dependencies(ctx):
     errs = []
     msg_tmpl = ("Unable to extract {0} data. "
                 "To receive {0} data, you also need to select {1}.")
 
-    for k,v in STREAM_DEPENDENCIES.items():
+    for k, v in STREAM_DEPENDENCIES.items():
         if k in ctx.selected_stream_ids and v not in ctx.selected_stream_ids:
             errs.append(msg_tmpl.format(k, v))
     if errs:
         raise DependencyException(" ".join(errs))
 
+
 def load_discovered_schema(stream):
     schema = load_schema(stream.tap_stream_id)
     mdata = metadata.new()
 
-    mdata = metadata.write(mdata, (), 'table-key-properties', stream.key_properties)
-    mdata = metadata.write(mdata, (), 'forced-replication-method', stream.replication_method)
+    mdata = metadata.write(
+        mdata, (), 'table-key-properties', stream.key_properties)
+    mdata = metadata.write(
+        mdata, (), 'forced-replication-method', stream.replication_method)
 
     if stream.replication_key:
-        mdata = metadata.write(mdata, (), 'valid-replication-keys', [stream.replication_key])
+        mdata = metadata.write(
+            mdata, (), 'valid-replication-keys', [stream.replication_key])
 
     for field_name, props in schema['properties'].items():
         if field_name in stream.key_properties or field_name == stream.replication_key:
-            mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
+            mdata = metadata.write(
+                mdata, ('properties', field_name), 'inclusion', 'automatic')
         else:
-            mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'available')
+            mdata = metadata.write(
+                mdata, ('properties', field_name), 'inclusion', 'available')
 
     # The engagements stream has nested data that we synthesize; The engagement field needs to be automatic
     if stream.tap_stream_id == "engagements":
-        mdata = metadata.write(mdata, ('properties', 'engagement'), 'inclusion', 'automatic')
-        mdata = metadata.write(mdata, ('properties', 'lastUpdated'), 'inclusion', 'automatic')
+        mdata = metadata.write(
+            mdata, ('properties', 'engagement'), 'inclusion', 'automatic')
+        mdata = metadata.write(
+            mdata, ('properties', 'lastUpdated'), 'inclusion', 'automatic')
 
     return schema, metadata.to_list(mdata)
+
 
 def discover_schemas():
     result = {'streams': []}
@@ -1067,7 +1225,8 @@ def discover_schemas():
                                   'metadata': mdata})
     # Load the contacts_by_company schema
     LOGGER.info('Loading schema for contacts_by_company')
-    contacts_by_company = Stream('contacts_by_company', _sync_contacts_by_company, ['company-id', 'contact-id'], None, 'FULL_TABLE')
+    contacts_by_company = Stream('contacts_by_company', _sync_contacts_by_company, [
+                                 'company-id', 'contact-id'], None, 'FULL_TABLE')
     schema, mdata = load_discovered_schema(contacts_by_company)
 
     result['streams'].append({'stream': CONTACTS_BY_COMPANY,
@@ -1077,9 +1236,11 @@ def discover_schemas():
 
     return result
 
+
 def do_discover():
     LOGGER.info('Loading schemas')
     json.dump(discover_schemas(), sys.stdout, indent=4)
+
 
 def main_impl():
     args = utils.parse_args(
@@ -1102,12 +1263,14 @@ def main_impl():
     else:
         LOGGER.info("No properties were selected")
 
+
 def main():
     try:
         main_impl()
     except Exception as exc:
         LOGGER.critical(exc)
         raise exc
+
 
 if __name__ == '__main__':
     main()

--- a/tap_hubspot/schemas/deal_pipeline_stages.json
+++ b/tap_hubspot/schemas/deal_pipeline_stages.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "pipelineId": {
+      "type": ["null", "string"]
+    },
+    "stageId": {
+      "type": ["null", "string"]
+    },
+    "label": {
+      "type": ["null", "string"]
+    },
+    "probability": {
+      "type": ["null", "number"]
+    },
+    "active": {
+      "type": ["null", "boolean"]
+    },
+    "displayOrder": {
+      "type": ["null", "integer"]
+    },
+    "closedWon": {
+      "type": ["null", "boolean"]
+    }
+  }
+}

--- a/tap_hubspot/schemas/deals.json
+++ b/tap_hubspot/schemas/deals.json
@@ -10,27 +10,28 @@
     "isDeleted": {
       "type": ["null", "boolean"]
     },
-    "associations": {
-      "type": ["null", "object"],
-      "properties": {
-        "associatedVids": {
-          "type": ["null", "array"],
-          "items": {
-            "type": ["null", "integer"]
-          }
-        },
-        "associatedCompanyIds": {
-          "type": ["null", "array"],
-          "items": {
-            "type": ["null", "integer"]
-          }
-        },
-        "associatedDealIds": {
-          "type": ["null", "array"],
-          "items": {
-            "type": ["null", "integer"]
-          }
-        }
+    "associatedVids": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "associatedCompanyIds": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "associatedDealIds": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "associatedTicketIds": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
       }
     }
   }


### PR DESCRIPTION
# Description of change
This change adds an optional config in config.json named `skip_property_extras_and_versions`, which allows tap users to select only the recent value of the properties from hubspot objects and skip any extras like timestamp, source, sourceId as well as the versions. The extras and version fields create an issue because of large number of columns created when using this tap with [target-bigquery](https://github.com/adswerve/target-bigquery). This option also allows the users to select only the recent data from hubspot if they don't require the versions and additional metadata related with the field values.

# Manual QA steps
- Run tap-hubspot in discovery mode and generate catalog
- Run tap-hubspot in sync mode. You will notice that objects like deals and companies that have `properties_` attributes will give the actual values of the properties instead of returning an object with value and other metadata (e.g. timestamp, source, sourceId)
 
# Risks
 - This change requires the discovery of the catalog again. So if you are running it in an existing pipeline, ensure that you update your catalog (properties) file.
 
# Rollback steps
 - revert this branch
