### PR TITLE
use proper env and move build time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - run:
           name: 'Integration Tests'
           command: |
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             run-test --tap=tap-hubspot \
@@ -56,7 +56,7 @@ workflows:
   build_daily:
     triggers:
       - schedule:
-          cron: "0 17 * * *"
+          cron: "0 6 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
# Description of change
Use the tap_tester_sandbox environment and move the build time to avoid collisions.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
