### PR TITLE
Qa/test client gets

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -41,7 +41,7 @@ class HubspotBaseTest(unittest.TestCase):
         return "tap-hubspot"
 
     def get_properties(self):
-        return {'start_date' : '2020-01-01T00:00:00Z'} # '2017-05-01T00:00:00Z' used by OG tests
+        return {'start_date' : '2021-05-02T00:00:00Z'} # '2017-05-01T00:00:00Z' used by OG tests
 
     def get_credentials(self):
         return {'refresh_token': os.getenv('TAP_HUBSPOT_REFRESH_TOKEN'),

--- a/tests/client.py
+++ b/tests/client.py
@@ -1,36 +1,392 @@
 import datetime
 import requests
+import backoff
 
+from  tap_tester import menagerie
 from base import HubspotBaseTest
 
-#url = https://api.hubapi.com/email/public/v1/campaigns/13054799?hapikey=demo
+
 BASE_URL = "https://api.hubapi.com"
+
+
 class TestClient():
 
+    ##########################################################################
+    ### CORE METHODS
+    ##########################################################################
+
+    def giveup(exc):
+        """Checks a response status code, returns True if unsuccessful unless rate limited."""
+        return exc.response is not None \
+            and 400 <= exc.response.status_code < 500 \
+            and exc.response.status_code != 429
+
+    @backoff.on_exception(backoff.constant,
+                          (requests.exceptions.RequestException,
+                           requests.exceptions.HTTPError),
+                          max_tries=5,
+                          jitter=None,
+                          giveup=giveup,
+                          interval=10)
+    def get(self, url, params=dict()):
+        """Perform a GET using the standard requests method and logs the action"""
+        response = requests.get(url, params=params, headers=self.HEADERS)
+        print(f"TEST CLIENT | GET {url} params={params}  STATUS: {response.status_code}")
+        response.raise_for_status()
+        json_response = response.json()
+
+        return json_response
+
+    def post(self, url, data, params=dict()):
+        """Perfroma a POST using the standard requests method and log the action"""
+        headers = self.HEADERS
+        headers['content-type'] = "application/json"
+
+        response = requests.post(url, json=data, params=params, headers=self.HEADERS)
+        print(f"TEST CLIENT | POST {url} params={params}  STATUS: {response.status_code}")
+        response.raise_for_status()
+        json_response = response.json()
+
+        return json_response
+
+    def denest_properties(self, stream, records):
+        """
+        Takes a list of records and checks each for a 'properties' key to denest.
+        Returns the list of denested records.
+        """
+        for record in records:
+            if record.get('properties'):
+                for property_key, property_value in record['properties'].items():
+
+                    # if any property has a versions object track it by the top level key 'properties_versions'
+                    if property_value.get('versions'):
+                        if not record.get('properties_versions'):
+                            record['properties_versions'] = []
+                        record['properties_versions'] += property_value['versions']
+
+                    # denest each property to be a top level key
+                    record[f'property_{property_key}'] = property_value
+
+        print(f"TEST CLIENT | Transforming {len(records)} {stream} records")
+        return records
+
+    ##########################################################################
+    ### GET
+    ##########################################################################
+
     def get_campaigns(self):
-        """Get all campaigns by id, then grab the details of each campaign"""
-        campaign_by_id_url = "https://api.hubapi.com/email/public/v1/campaigns/by-id"
-        campaign_url = "https://api.hubapi.com/email/public/v1/campaigns/"
+        """
+        Get all campaigns by id, then grab the details of each campaign.
+        """
+        campaign_by_id_url = f"{BASE_URL}/email/public/v1/campaigns/by-id"
+        campaign_url = f"{BASE_URL}/email/public/v1/campaigns/"
 
-        headers = {'Authorization': f"Bearer {self.CONFIG['access_token']}"}
+        # get all campaigns by-id
+        response = self.get(campaign_by_id_url)
+        campaign_ids = [campaign['id'] for campaign in response['campaigns']]
 
-        resp = requests.get(campaign_by_id_url, headers=headers)
-        resp.raise_for_status()
-        json_resp = resp.json()
-
-        campaign_ids = [campaign['id'] for campaign in json_resp['campaigns']]
-
-        campaigns = []
+        # get the detailed record corresponding to each campagin-id
+        records = []
         for campaign_id in campaign_ids:
             url = f"{campaign_url}{campaign_id}"
-            resp = requests.get(url, headers=headers)
-            resp.raise_for_status()
-            json_resp = resp.json()
-            campaigns.append(json_resp)
+            response = self.get(url)
+            records.append(response)
 
-        return campaigns
+        return records
+
+    def get_companies(self, since):
+        """
+        Get all companies by paginating using 'hasMore' and 'offset'.
+        """
+        url = f"{BASE_URL}/companies/v2/companies/recent/modified"
+        since = str(datetime.datetime.strptime(since, "%Y-%m-%dT00:00:00.000000Z").timestamp() * 1000)[:-2]
+        params = {'since': since}
+        records = []
+
+        # paginating through all the companies
+        companies = []
+        has_more = True
+        while has_more:
+
+            response = self.get(url, params=params)
+            companies.extend(response['results'])
+
+            has_more = response['hasMore']
+            params['offset'] = response['offset']
+
+        # get the details of each company
+        for company in companies:
+            url = f"{BASE_URL}/companies/v2/companies/{company['companyId']}"
+            response = self.get(url)
+            records.append(response)
+
+        records = self.denest_properties('companies', records)
+
+        return records
+
+    def get_contact_lists(self):
+        """
+        Get all contact_lists by paginating using 'has-more' and 'offset'.
+        """
+        url = f"{BASE_URL}/contacts/v1/lists"
+        params = dict()
+        records = []
+        replication_key = list(self.replication_keys['contact_lists'])[0]
+        # paginating through all the contact_lists
+        has_more = True
+        while has_more:
+
+            response = self.get(url, params=params)
+            for record in response['lists']:
+                if self.start_date < record[replication_key]:
+                    records.append(record)
+
+            has_more = response['has-more']
+            params['offset'] = response['offset']
+
+        return records
+
+    def get_contacts(self):
+        """
+        Get all contact vids by paginating using 'has-more' and 'vid-offset/vidOffset'.
+        Then use the vids to grab the detailed contacts records.
+        """
+        url_1 = f"{BASE_URL}/contacts/v1/lists/all/contacts/all"
+        params_1 = {
+            'showListMemberships': True,
+            'includeVersion': True,
+            'count': 100,
+        }
+        vids = []
+        url_2 = f"{BASE_URL}/contacts/v1/contact/vids/batch/"
+        params_2 = {
+            'showListMemberships': True,
+            'formSubmissionMode': "all",
+        }
+        records = []
+
+        has_more = True
+        while has_more:
+
+            # get a page worth of contacts and pull the vids
+            response_1 = self.get(url_1, params=params_1)
+            vids = [record['vid'] for record in response_1['contacts']]
+
+            has_more = response_1['has-more']
+            params_1['vidOffset'] = response_1['vid-offset']
+
+            # get the detailed contacts records by vids
+            params_2['vid'] = vids
+            response_2 = self.get(url_2, params=params_2)
+            records.extend([record for record in response_2.values()])
+
+        records = self.denest_properties('contacts', records)
+        return records
+
+
+    def get_contacts_by_company(self, parent_ids):
+        """
+        Get all contacts_by_company iterating over compnayId's and
+        paginating using 'hasMore' and 'vidOffset'. This stream is essentially
+        a join on contacts and companies.
+
+        NB: This stream is a CHILD of 'companies'. If any test needs to pull expected
+            data from this endpoint, it requires getting all 'companies' data and then
+            pulling the 'companyId' from each record to perform the corresponding get here.
+        """
+        url = f"{BASE_URL}/companies/v2/companies/<company_id>/vids"
+        params = dict()
+        records = []
+
+        for parent_id in parent_ids:
+            child_url = url.replace('<company_id>', str(parent_id))
+            response = self.get(child_url, params=params)
+
+            has_more = True
+            while has_more:
+
+                response = self.get(child_url, params=params)
+                for vid in response.get('vids', {}):
+                    records.extend([{'company-id': parent_id,
+                                     'contact-id': vid}])
+
+                has_more = response['hasMore']
+                params['vidOffset'] = response['vidOffset']
+
+            params = dict()
+
+        return records
+
+    def get_deal_pipelines(self):
+        """
+        Get all deal_pipelines.
+        """
+        url = f"{BASE_URL}/deals/v1/pipelines"
+        records = []
+
+        response = self.get(url)
+        records.extend(response)
+
+        records = self.denest_properties('deal_pipelines', records)
+        return records
+
+    def get_deals(self):
+        """
+        Get all deals by paginating using 'hasMore' and 'offset'.
+        """
+        v1_url = f"{BASE_URL}/deals/v1/deal/paged"
+
+        params = {'includeAllProperties': True,
+                  'allPropertiesFetchMode': 'latest_version',
+                  'properties' : []}
+        # 'includeAssociations': False, TODO do we want this?
+        v3_prefixes = {'hs_time_in_closedlost'}
+        # 'hs_date_entered_', 'hs_date_exited', 'hs_time_in',
+        replication_key = list(self.replication_keys['deals'])[0]
+        records = []
+        # hit the v1 endpoint to get the record
+        has_more = True
+        while has_more:
+
+            response = self.get(v1_url, params=params)
+            records.extend([record for record in response['deals']
+                            if record['properties'][replication_key]['timestamp'] >= self.start_date])
+
+            has_more = response['hasMore']
+            params['offset'] = response['offset']
+
+        # TODO this should be done for every page
+        # hit the v3 endpoint to get the special hs_<whatever> fields from  v3 'properties'
+        v3_url = f"{BASE_URL}/crm/v3/objects/deals/batch/read"
+
+        v1_ids = [{'id': str(record['dealId'])} for record in records]
+        data = {'inputs': v1_ids,
+                'properties': list(v3_prefixes)}
+        v3_response = self.post(v3_url, data, params)
+
+        v3_records = v3_response['results']
+        for v3_record in v3_records:
+            for record in records:
+                if v3_record['id'] == record['dealId']:
+                    record['properteis'].update(v3_record['properties'])
+
+        records = self.denest_properties('deals', records)
+        return records
+
+    def get_email_events(self):
+        """
+        Get all email_events by paginating using 'hasMore' and 'offset'.
+        """
+        url = f"{BASE_URL}/email/public/v1/events"
+        replication_key = list(self.replication_keys['email_events'])[0]
+        params = dict()
+        records = []
+
+        has_more = True
+        while has_more:
+
+            response = self.get(url, params=params)
+            records.extend([record for record in response['events']
+                            if record['created'] >= self.start_date])
+
+            has_more = response['hasMore']
+            params['offset'] = response['offset']
+
+        return records
+
+    def get_engagements(self):
+        """
+        Get all engagements by paginating using 'hasMore' and 'offset'.
+        """
+        url = f"{BASE_URL}/engagements/v1/engagements/paged"
+        replication_key = list(self.replication_keys['engagements'])[0]
+        params = dict()
+        records = []
+
+        has_more = True
+        while has_more:
+
+            response = self.get(url, params=params)
+            for result in response['results']:
+                if result['engagement'][replication_key] >= self.start_date:
+                    result_dict = result
+                    result_dict['engagement'] = result['engagement']
+                    result_dict['engagement_id'] = result['engagement']['id']
+                    result_dict['lastUpdated'] = result['engagement']['lastUpdated']
+
+                    records.append(result_dict)
+
+            has_more = response['hasMore']
+            params['offset'] = response['offset']
+
+        return records
+
+    def get_forms(self):
+        """
+        Get all forms.
+        """
+        url = f"{BASE_URL}/forms/v2/forms"
+        replication_key = list(self.replication_keys['forms'])[0]
+        records = []
+
+        response = self.get(url)
+        records.extend([record for record in response
+                        if record[replication_key] >= self.start_date])
+
+        return records
+
+    def get_owners(self):
+        """
+        Get all owners.
+        """
+        url = f"{BASE_URL}/owners/v2/owners"
+        records = []
+
+        response = self.get(url)
+        records.extend(response)
+
+        return records
+
+    def get_subscription_changes(self):
+        """
+        Get all subscription_changes by paginating using 'hasMore' and 'offset'.
+        """
+        url = f"{BASE_URL}/email/public/v1/subscriptions/timeline"
+        params = dict()
+        records = []
+
+        has_more = True
+        while has_more:
+
+            response = self.get(url, params=params)
+            records.extend(response['timeline'])
+
+            has_more = response['hasMore']
+            params['offset'] = response['offset']
+
+
+        return records
+
+    def get_workflows(self):
+        """
+        Get all workflows.
+        """
+        url = f"{BASE_URL}/automation/v3/workflows"
+        replication_key = list(self.replication_keys['workflows'])[0]
+        records = []
+
+        response = self.get(url)
+        records.extend([record for record in response['workflows']
+                        if record[replication_key] >= self.start_date])
+
+        return records
+
+    ##########################################################################
+    ### OAUTH
+    ##########################################################################
 
     def acquire_access_token_from_refresh_token(self):
+        # TODO does this limit test parallelization to n=1??
         # TODO just import this from the tap to lessen the maintenance burden
         payload = {
             "grant_type": "refresh_token",
@@ -40,20 +396,26 @@ class TestClient():
             "client_secret": self.CONFIG['client_secret'],
         }
 
-        resp = requests.post(BASE_URL + "/oauth/v1/token", data=payload)
-        resp.raise_for_status()
-        auth = resp.json()
+        response = requests.post(BASE_URL + "/oauth/v1/token", data=payload)
+        response.raise_for_status()
+        auth = response.json()
         self.CONFIG['access_token'] = auth['access_token']
         self.CONFIG['refresh_token'] = auth['refresh_token']
         self.CONFIG['token_expires'] = (
             datetime.datetime.utcnow() +
             datetime.timedelta(seconds=auth['expires_in'] - 600))
-        print(f"Token refreshed. Expires at {self.CONFIG['token_expires']}")
+        print(f"TEST CLIENT | Token refreshed. Expires at {self.CONFIG['token_expires']}")
 
     def __init__(self):
         self.BaseTest = HubspotBaseTest()
+        self.replication_keys = self.BaseTest.expected_replication_keys()
 
         self.CONFIG = self.BaseTest.get_credentials()
         self.CONFIG.update(self.BaseTest.get_properties())
 
+        self.start_date = datetime.datetime.strptime(
+            self.CONFIG['start_date'], self.BaseTest.START_DATE_FORMAT).timestamp() * 1000
+
         self.acquire_access_token_from_refresh_token()
+
+        self.HEADERS = {'Authorization': f"Bearer {self.CONFIG['access_token']}"}

--- a/tests/client.py
+++ b/tests/client.py
@@ -1,0 +1,59 @@
+import datetime
+import requests
+
+from base import HubspotBaseTest
+
+#url = https://api.hubapi.com/email/public/v1/campaigns/13054799?hapikey=demo
+BASE_URL = "https://api.hubapi.com"
+class TestClient():
+
+    def get_campaigns(self):
+        """Get all campaigns by id, then grab the details of each campaign"""
+        campaign_by_id_url = "https://api.hubapi.com/email/public/v1/campaigns/by-id"
+        campaign_url = "https://api.hubapi.com/email/public/v1/campaigns/"
+
+        headers = {'Authorization': f"Bearer {self.CONFIG['access_token']}"}
+
+        resp = requests.get(campaign_by_id_url, headers=headers)
+        resp.raise_for_status()
+        json_resp = resp.json()
+
+        campaign_ids = [campaign['id'] for campaign in json_resp['campaigns']]
+
+        campaigns = []
+        for campaign_id in campaign_ids:
+            url = f"{campaign_url}{campaign_id}"
+            resp = requests.get(url, headers=headers)
+            resp.raise_for_status()
+            json_resp = resp.json()
+            campaigns.append(json_resp)
+
+        return campaigns
+
+    def acquire_access_token_from_refresh_token(self):
+        # TODO just import this from the tap to lessen the maintenance burden
+        payload = {
+            "grant_type": "refresh_token",
+            "redirect_uri": self.CONFIG['redirect_uri'],
+            "refresh_token": self.CONFIG['refresh_token'],
+            "client_id": self.CONFIG['client_id'],
+            "client_secret": self.CONFIG['client_secret'],
+        }
+
+        resp = requests.post(BASE_URL + "/oauth/v1/token", data=payload)
+        resp.raise_for_status()
+        auth = resp.json()
+        self.CONFIG['access_token'] = auth['access_token']
+        self.CONFIG['refresh_token'] = auth['refresh_token']
+        self.CONFIG['token_expires'] = (
+            datetime.datetime.utcnow() +
+            datetime.timedelta(seconds=auth['expires_in'] - 600))
+        print(f"Token refreshed. Expires at {self.CONFIG['token_expires']}")
+
+    def __init__(self):
+        self.BaseTest = HubspotBaseTest()
+
+        self.CONFIG = self.BaseTest.get_credentials()
+        self.CONFIG.update(self.BaseTest.get_properties())
+
+        self.acquire_access_token_from_refresh_token()

--- a/tests/test_hubspot_all_fields_test.py
+++ b/tests/test_hubspot_all_fields_test.py
@@ -13,12 +13,12 @@ KNOWN_EXTRA_FIELDS = {
     },
 }
 
-KNOWN_MISSING_FIELDS = { # TODO need to write up the following discrepancy
-    'contact_lists': {
+KNOWN_MISSING_FIELDS = {
+    'contact_lists': {  # BUG https://jira.talendforge.org/browse/TDL-14996
         'authorId',
         'teamIds'
     },
-    'email_events': {
+    'email_events': {  # BUG https://jira.talendforge.org/browse/TDL-14997
         'portalSubscriptionStatus',
         'attempt',
         'source',
@@ -30,7 +30,7 @@ KNOWN_MISSING_FIELDS = { # TODO need to write up the following discrepancy
         'suppressedReason',
         'cc',
      },
-    'workflows': {
+    'workflows': {  # BUG https://jira.talendforge.org/browse/TDL-14998
         'migrationStatus',
         'updateSource',
         'description',
@@ -40,10 +40,10 @@ KNOWN_MISSING_FIELDS = { # TODO need to write up the following discrepancy
         'portalId',
         'contactCounts',
     },
-    'owners': {
+    'owners': {  # BUG https://jira.talendforge.org/browse/TDL-15000
         'activeSalesforceId'
     },
-    'forms': {
+    'forms': {  # BUG https://jira.talendforge.org/browse/TDL-15001
         'alwaysCreateNewCompany',
         'themeColor',
         'publishAt',
@@ -64,73 +64,23 @@ KNOWN_MISSING_FIELDS = { # TODO need to write up the following discrepancy
         'customUid',
         'isPublished',
     },
-    'companies': {
+    'companies': {  # BUG https://jira.talendforge.org/browse/TDL-15003
         'mergeAudits',
         'stateChanges',
         'isDeleted',
         'additionalDomains',
     },
-    'campaigns': {
+    'campaigns': {  # BUG https://jira.talendforge.org/browse/TDL-15003
         'lastProcessingStateChangeAt',
         'lastProcessingFinishedAt',
         'processingState',
         'lastProcessingStartedAt',
     },
-    'deals': {
+    'deals': {  # BUG https://jira.talendforge.org/browse/TDL-14999
         'imports',
         'property_hs_num_associated_deal_splits',
         'stateChanges',
     },
-    # 'deals': {
-    #     # This field requires attaching conferencing software to
-    #     # Hubspot and booking a meeting as part of a deal
-    #     'property_engagements_last_meeting_booked',
-    #     # These 3 fields are derived from UTM codes attached to the above
-    #     # meetings
-    #     'property_engagements_last_meeting_booked_campaign',
-    #     'property_engagements_last_meeting_booked_medium',
-    #     'property_engagements_last_meeting_booked_source',
-    #     # There's a way to associate a deal with a marketing campaign
-    #     'property_hs_campaign',
-    #     'property_hs_deal_amount_calculation_preference',
-    #     # These are calculated properties
-    #     'property_hs_likelihood_to_close',
-    #     'property_hs_merged_object_ids',
-    #     'property_hs_predicted_amount',
-    #     'property_hs_predicted_amount_in_home_currency',
-    #     'property_hs_sales_email_last_replied',
-    #     # These we have no data for
-    #     'property_hs_date_entered_appointmentscheduled',
-    #     'property_hs_date_entered_decisionmakerboughtin',
-    #     'property_hs_date_exited_qualifiedtobuy',
-    #     'property_hs_time_in_closedwon',
-    #     'property_hs_date_exited_appointmentscheduled',
-    #     'property_hs_time_in_decisionmakerboughtin',
-    #     'property_hs_date_exited_closedlost',
-    #     'property_hs_time_in_closedlost',
-    #     'property_hs_date_entered_closedlost',
-    #     'property_hs_date_entered_closedwon',
-    #     'property_hs_date_exited_contractsent',
-    #     'property_hs_time_in_presentationscheduled',
-    #     'property_hs_date_exited_presentationscheduled',
-    #     'property_hs_time_in_qualifiedtobuy',
-    #     'property_hs_date_exited_decisionmakerboughtin',
-    #     'property_hs_time_in_contractsent',
-    #     'property_hs_time_in_appointmentscheduled',
-    #     'property_hs_date_entered_presentationscheduled',
-    #     'property_hs_date_entered_qualifiedtobuy',
-    #     'property_hs_date_entered_contractsent',
-    #     'property_hs_date_exited_closedwon',
-    #     # BUG https://jira.talendforge.org/browse/TDL-9886
-    #     #     The following streams have been added since tests were written
-    #     'property_hs_all_assigned_business_unit_ids',
-    #     'property_hs_unique_creation_key',
-    #     'property_hs_num_target_accounts',
-    #     'property_hs_priority',
-    #     'property_hs_user_ids_of_all_notification_unfollowers',
-    #     'property_hs_deal_stage_probability_shadow',
-    #     'property_hs_user_ids_of_all_notification_followers',
-    # },
 }
 
 class TestHubspotAllFields(HubspotBaseTest):
@@ -140,21 +90,11 @@ class TestHubspotAllFields(HubspotBaseTest):
         return "tap_tester_all_fields_all_fields_test"
 
     def testable_streams(self):
-        return {
-            'deals',
-            'deal_pipelines',
-            'contacts',  # pass
-            'companies', # pass
-            'campaigns', # pass
-            'contact_lists', # pass
-            'contacts_by_company', # 
-            'email_events', # pass
-            'engagements', # pass
-            'forms', # pass
-            'owners', # pass
-            'workflows', # pass
-            # 'subscription_changes', # BUG https://jira.talendforge.org/browse/TDL-14938
-        }
+        """expected streams minus the streams not under test"""
+        return self.expected_streams().difference({
+            'subscription_changes', # BUG_TDL-14938 https://jira.talendforge.org/browse/TDL-14938
+        })
+
 
     @classmethod
     def setUpClass(cls):
@@ -165,7 +105,6 @@ class TestHubspotAllFields(HubspotBaseTest):
         test_client = TestClient()
         cls.expected_records = dict()
 
-        # pass
         cls.expected_records['campaigns'] = test_client.get_campaigns()
         cls.expected_records['forms'] = test_client.get_forms()
         cls.expected_records['owners'] = test_client.get_owners()
@@ -179,10 +118,9 @@ class TestHubspotAllFields(HubspotBaseTest):
         cls.expected_records['contacts_by_company'] = test_client.get_contacts_by_company(parent_ids=company_ids)
         cls.expected_records['deal_pipelines'] = test_client.get_deal_pipelines()
         cls.expected_records['deals'] = test_client.get_deals()
-        # fail
-        # cls.expected_records['subscription_changes'] = test_client.get_subscription_changes()
+        # cls.expected_records['subscription_changes'] = test_client.get_subscription_changes()  # see BUG_TDL-14938
 
-
+        # cls.expected_records = get_expected_records_from_test_client() # TODO?
 
         for stream, records in cls.expected_records.items():
             print(f"The test client found {len(records)} {stream} records.")
@@ -221,8 +159,6 @@ class TestHubspotAllFields(HubspotBaseTest):
                 # gather expected values
                 replication_method = self.expected_replication_method()[stream]
                 primary_keys = self.expected_primary_keys()[stream]
-                expected_primary_key_values = [[record[primary_key] for primary_key in primary_keys]
-                                               for record in self.expected_records[stream]]
 
                 # gather replicated records
                 actual_records = [message['data']
@@ -244,10 +180,9 @@ class TestHubspotAllFields(HubspotBaseTest):
                         actual_record = matching_actual_records_by_pk[0]
 
 
-                        # TODO BUG
-                        #      KNOWN_MISSING_FIELDS is a dictionary of streams to aggregated missing fields.
-                        #      We will check each expected_record to see which of the known keys is present in expectations
-                        #      and then will add them to the known_missing_keys set.
+                        # NB: KNOWN_MISSING_FIELDS is a dictionary of streams to aggregated missing fields.
+                        #     We will check each expected_record to see which of the known keys is present in expectations
+                        #     and then will add them to the known_missing_keys set.
                         known_missing_keys = set()
                         for missing_key in KNOWN_MISSING_FIELDS.get(stream, set()):
                             if missing_key in expected_record.keys():
@@ -258,7 +193,7 @@ class TestHubspotAllFields(HubspotBaseTest):
                         known_extra_keys = set()
                         for extra_key in KNOWN_EXTRA_FIELDS.get(stream, set()):
                             known_extra_keys.add(extra_key)
-                            
+
 
                         # Verify the fields in our expected record match the fields in the corresponding replicated record
                         expected_keys_adjusted = set(expected_record.keys()).union(known_extra_keys)
@@ -266,12 +201,11 @@ class TestHubspotAllFields(HubspotBaseTest):
 
                         self.assertSetEqual(expected_keys_adjusted, actual_keys_adjusted)
 
-                # TODO PUT BACK
-
-                # BUG ? TEST ISSUE ? TODO
-                # if stream not in {'companies'}:
-                #     # Verify by primary key values that only the expected records were replicated
-                #     actual_records_primary_key_values = [[record[primary_key]
-                #                                           for primary_key in primary_keys]
-                #                                          for record in actual_records]
-                #     self.assertEqual(expected_primary_key_values, actual_records_primary_key_values)
+                # Verify by primary key values that only the expected records were replicated
+                expected_primary_key_values = {tuple([record[primary_key]
+                                                      for primary_key in primary_keys])
+                                               for record in self.expected_records[stream]}
+                actual_records_primary_key_values = {tuple([record[primary_key]
+                                                            for primary_key in primary_keys])
+                                                     for record in actual_records}
+                self.assertSetEqual(expected_primary_key_values, actual_records_primary_key_values)

--- a/tests/test_hubspot_all_fields_test.py
+++ b/tests/test_hubspot_all_fields_test.py
@@ -5,64 +5,119 @@ import tap_tester.runner      as runner
 from base import HubspotBaseTest
 from client import TestClient
 
-KNOWN_MISSING_FIELDS = {
+KNOWN_MISSING_FIELDS = { # TODO need to write up the following discrepancy
+    'contact_lists': {
+        'authorId',
+        'teamIds'
+    },
+    'email_events': {
+        'portalSubscriptionStatus',
+        'attempt',
+        'source',
+        'subscriptions',
+        'sourceId',
+        'replyTo',
+        'suppressedMessage',
+        'bcc',
+        'suppressedReason',
+        'cc',
+     },
+    'workflows': {
+        'migrationStatus',
+        'updateSource',
+        'description',
+        'originalAuthorUserId',
+        'lastUpdatedByUserId',
+        'creationSource',
+        'portalId',
+        'contactCounts',
+    },
+    'owners': {
+        'activeSalesforceId'
+    },
+    'forms': {
+        'alwaysCreateNewCompany',
+        'themeColor',
+        'publishAt',
+        'editVersion',
+        'themeName',
+        'style',
+        'thankYouMessageJson',
+        'createMarketableContact',
+        'kickbackEmailWorkflowId',
+        'businessUnitId',
+        'portableKey',
+        'parentId',
+        'kickbackEmailsJson',
+        'unpublishAt',
+        'internalUpdatedAt',
+        'multivariateTest',
+        'publishedAt',
+        'customUid',
+        'isPublished',
+    },
+    'companies': {
+        'mergeAudits',
+        'stateChanges',
+        'isDeleted',
+        'additionalDomains',
+    },
     'campaigns': {
-        # TODO need to write up the following discrepancy
         'lastProcessingStateChangeAt',
         'lastProcessingFinishedAt',
         'processingState',
         'lastProcessingStartedAt',
     },
-    'deals': {
-        # This field requires attaching conferencing software to
-        # Hubspot and booking a meeting as part of a deal
-        'property_engagements_last_meeting_booked',
-        # These 3 fields are derived from UTM codes attached to the above
-        # meetings
-        'property_engagements_last_meeting_booked_campaign',
-        'property_engagements_last_meeting_booked_medium',
-        'property_engagements_last_meeting_booked_source',
-        # There's a way to associate a deal with a marketing campaign
-        'property_hs_campaign',
-        'property_hs_deal_amount_calculation_preference',
-        # These are calculated properties
-        'property_hs_likelihood_to_close',
-        'property_hs_merged_object_ids',
-        'property_hs_predicted_amount',
-        'property_hs_predicted_amount_in_home_currency',
-        'property_hs_sales_email_last_replied',
-        # These we have no data for
-        'property_hs_date_entered_appointmentscheduled',
-        'property_hs_date_entered_decisionmakerboughtin',
-        'property_hs_date_exited_qualifiedtobuy',
-        'property_hs_time_in_closedwon',
-        'property_hs_date_exited_appointmentscheduled',
-        'property_hs_time_in_decisionmakerboughtin',
-        'property_hs_date_exited_closedlost',
-        'property_hs_time_in_closedlost',
-        'property_hs_date_entered_closedlost',
-        'property_hs_date_entered_closedwon',
-        'property_hs_date_exited_contractsent',
-        'property_hs_time_in_presentationscheduled',
-        'property_hs_date_exited_presentationscheduled',
-        'property_hs_time_in_qualifiedtobuy',
-        'property_hs_date_exited_decisionmakerboughtin',
-        'property_hs_time_in_contractsent',
-        'property_hs_time_in_appointmentscheduled',
-        'property_hs_date_entered_presentationscheduled',
-        'property_hs_date_entered_qualifiedtobuy',
-        'property_hs_date_entered_contractsent',
-        'property_hs_date_exited_closedwon',
-        # BUG https://jira.talendforge.org/browse/TDL-9886
-        #     The following streams have been added since tests were written
-        'property_hs_all_assigned_business_unit_ids',
-        'property_hs_unique_creation_key',
-        'property_hs_num_target_accounts',
-        'property_hs_priority',
-        'property_hs_user_ids_of_all_notification_unfollowers',
-        'property_hs_deal_stage_probability_shadow',
-        'property_hs_user_ids_of_all_notification_followers',
-    },
+    # 'deals': {
+    #     # This field requires attaching conferencing software to
+    #     # Hubspot and booking a meeting as part of a deal
+    #     'property_engagements_last_meeting_booked',
+    #     # These 3 fields are derived from UTM codes attached to the above
+    #     # meetings
+    #     'property_engagements_last_meeting_booked_campaign',
+    #     'property_engagements_last_meeting_booked_medium',
+    #     'property_engagements_last_meeting_booked_source',
+    #     # There's a way to associate a deal with a marketing campaign
+    #     'property_hs_campaign',
+    #     'property_hs_deal_amount_calculation_preference',
+    #     # These are calculated properties
+    #     'property_hs_likelihood_to_close',
+    #     'property_hs_merged_object_ids',
+    #     'property_hs_predicted_amount',
+    #     'property_hs_predicted_amount_in_home_currency',
+    #     'property_hs_sales_email_last_replied',
+    #     # These we have no data for
+    #     'property_hs_date_entered_appointmentscheduled',
+    #     'property_hs_date_entered_decisionmakerboughtin',
+    #     'property_hs_date_exited_qualifiedtobuy',
+    #     'property_hs_time_in_closedwon',
+    #     'property_hs_date_exited_appointmentscheduled',
+    #     'property_hs_time_in_decisionmakerboughtin',
+    #     'property_hs_date_exited_closedlost',
+    #     'property_hs_time_in_closedlost',
+    #     'property_hs_date_entered_closedlost',
+    #     'property_hs_date_entered_closedwon',
+    #     'property_hs_date_exited_contractsent',
+    #     'property_hs_time_in_presentationscheduled',
+    #     'property_hs_date_exited_presentationscheduled',
+    #     'property_hs_time_in_qualifiedtobuy',
+    #     'property_hs_date_exited_decisionmakerboughtin',
+    #     'property_hs_time_in_contractsent',
+    #     'property_hs_time_in_appointmentscheduled',
+    #     'property_hs_date_entered_presentationscheduled',
+    #     'property_hs_date_entered_qualifiedtobuy',
+    #     'property_hs_date_entered_contractsent',
+    #     'property_hs_date_exited_closedwon',
+    #     # BUG https://jira.talendforge.org/browse/TDL-9886
+    #     #     The following streams have been added since tests were written
+    #     'property_hs_all_assigned_business_unit_ids',
+    #     'property_hs_unique_creation_key',
+    #     'property_hs_num_target_accounts',
+    #     'property_hs_priority',
+    #     'property_hs_user_ids_of_all_notification_unfollowers',
+    #     'property_hs_deal_stage_probability_shadow',
+    #     'property_hs_user_ids_of_all_notification_followers',
+    # },
 }
 
 class TestHubspotAllFields(HubspotBaseTest):
@@ -73,23 +128,71 @@ class TestHubspotAllFields(HubspotBaseTest):
 
     def testable_streams(self):
         return {
-            #'deals',
-            'campaigns',
+            # 'deals',
+            'deal_pipelines',
+            # 'contacts',  # pass
+            # 'companies', # pass
+            # 'campaigns', # pass
+            # 'contact_lists', # pass
+            # 'contacts_by_company', # fail TODO BUG? Only 1 record replicated
+            # 'email_events', # pass
+            # 'engagements', # pass
+            # 'forms', # pass
+            # 'owners', # pass
+            # 'workflows', # pass
+            # 'subscription_changes', # TODO cannot be tested easily without a valid pk
         }
 
-    def test_run(self):
+    @classmethod
+    def setUpClass(cls):
+        cls.maxDiff = None  # see all output in failure
+
+        cls.my_timestamp = '2021-08-05T00:00:00.000000Z'
+
         test_client = TestClient()
-        expected_records = dict()
-        expected_records['campaigns'] = test_client.get_campaigns()
-        
+        cls.expected_records = dict()
+
+        # pass
+        # cls.expected_records['campaigns'] = test_client.get_campaigns()
+        # cls.expected_records['forms'] = test_client.get_forms()
+        # cls.expected_records['owners'] = test_client.get_owners()
+        # cls.expected_records['engagements'] = test_client.get_engagements()
+        # cls.expected_records['workflows'] = test_client.get_workflows()
+        # cls.expected_records['email_events'] = test_client.get_email_events()
+        # cls.expected_records['contact_lists'] = test_client.get_contact_lists()
+        #cls.expected_records['contacts'] = test_client.get_contacts()
+        # cls.expected_records['companies'] = test_client.get_companies(since=cls.my_timestamp)
+        # company_ids = [company['companyId'] for company in cls.expected_records['companies']]
+        # cls.expected_records['contacts_by_company'] = test_client.get_contacts_by_company(parent_ids=company_ids)
+        # fail
+        # cls.expected_records['subscription_changes'] = test_client.get_subscription_changes()
+
+
+        # cls.expected_records['deals'] = test_client.get_deals() # TODO work with dev to get passing
+
+
+
+        # TODO
+        cls.expected_records['deal_pipelines'] = test_client.get_deal_pipelines()
+
+        for stream, records in cls.expected_records.items():
+            print(f"The test client found {len(records)} {stream} records.")
+
+    def test_run(self):
         conn_id = connections.ensure_connection(self)
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 
+        # moving the state up so the sync will be shorter and the test takes less time
+        state = {'bookmarks': {'companies': {'current_sync_start': None,
+                                             'hs_lastmodifieddate': self.my_timestamp,
+                                             'offset': {}}},
+                 'currently_syncing': None}
+        menagerie.set_state(conn_id, state)
+
         # Select only the expected streams tables
         expected_streams = self.testable_streams()
         catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
-
         for catalog_entry in catalog_entries:
             stream_schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
             connections.select_catalog_and_fields_via_metadata(
@@ -100,34 +203,31 @@ class TestHubspotAllFields(HubspotBaseTest):
 
         # Run sync
         first_record_count_by_stream = self.run_and_verify_sync(conn_id)
-
-        replicated_row_count = sum(first_record_count_by_stream.values())
         synced_records = runner.get_records_from_target_output()
 
         # Test by Stream
-        for stream in self.testable_streams():
+        for stream in expected_streams:
             with self.subTest(stream=stream):
 
+                # gather expected values
                 replication_method = self.expected_replication_method()[stream]
                 primary_keys = self.expected_primary_keys()[stream]
                 expected_primary_key_values = [[record[primary_key] for primary_key in primary_keys]
-                                               for record in expected_records[stream]]
+                                               for record in self.expected_records[stream]]
+
+                # gather replicated records
                 actual_records = [message['data']
                                   for message in synced_records[stream]['messages']
                                   if message['action'] == 'upsert']
- 
 
-                # Verify by primary key values that only the expected records were replicated
-                actual_records_primary_key_values = [[record[primary_key]
-                                                      for primary_key in primary_keys]
-                                                     for record in actual_records]
-                self.assertEqual(expected_primary_key_values, actual_records_primary_key_values)
+                for expected_record in self.expected_records[stream]:
 
-                for expected_record in expected_records[stream]:
-                    with self.subTest(expected_record=expected_record):
- 
+                    primary_key_dict = {primary_key: expected_record[primary_key] for primary_key in primary_keys}
+                    primary_key_values = list(primary_key_dict.values())
+
+                    with self.subTest(expected_record=primary_key_dict):
+
                         # grab the replicated record that corresponds to expected_record by checking primary keys
-                        primary_key_values = [expected_record[primary_key] for primary_key in primary_keys]
                         matching_actual_records_by_pk = [record for record in actual_records
                                                          if primary_key_values == [record[primary_key]
                                                                                    for primary_key in primary_keys]]
@@ -135,7 +235,26 @@ class TestHubspotAllFields(HubspotBaseTest):
                         actual_record = matching_actual_records_by_pk[0]
 
 
+                        # TODO BUG
+                        #      KNOWN_MISSING_FIELDS is a dictionary of streams to aggregated missing fields.
+                        #      We will check each expected_record to see which of the known keys is present in expectations
+                        #      and then will add them to the known_missing_keys set.
+                        known_missing_keys = set()
+                        for missing_key in KNOWN_MISSING_FIELDS.get(stream, set()):
+                            if missing_key in expected_record.keys():
+                                known_missing_keys.add(missing_key)
+
                         # Verify the fields in our expected record match the fields in the corresponding replicated record
                         self.assertSetEqual(
-                            set(expected_record.keys()), set(actual_record.keys()).union(KNOWN_MISSING_FIELDS[stream])
+                            set(expected_record.keys()), set(actual_record.keys()).union(known_missing_keys)
                         )
+
+                # TODO PUT BACK
+
+                # BUG ? TEST ISSUE ? TODO
+                # if stream not in {'companies'}:
+                #     # Verify by primary key values that only the expected records were replicated
+                #     actual_records_primary_key_values = [[record[primary_key]
+                #                                           for primary_key in primary_keys]
+                #                                          for record in actual_records]
+                #     self.assertEqual(expected_primary_key_values, actual_records_primary_key_values)

--- a/tests/test_hubspot_all_fields_test.py
+++ b/tests/test_hubspot_all_fields_test.py
@@ -130,16 +130,16 @@ class TestHubspotAllFields(HubspotBaseTest):
         return {
             # 'deals',
             'deal_pipelines',
-            # 'contacts',  # pass
-            # 'companies', # pass
-            # 'campaigns', # pass
-            # 'contact_lists', # pass
-            # 'contacts_by_company', # fail TODO BUG? Only 1 record replicated
-            # 'email_events', # pass
-            # 'engagements', # pass
-            # 'forms', # pass
-            # 'owners', # pass
-            # 'workflows', # pass
+            'contacts',  # pass
+            'companies', # pass
+            'campaigns', # pass
+            'contact_lists', # pass
+            'contacts_by_company', # 
+            'email_events', # pass
+            'engagements', # pass
+            'forms', # pass
+            'owners', # pass
+            'workflows', # pass
             # 'subscription_changes', # TODO cannot be tested easily without a valid pk
         }
 
@@ -153,27 +153,23 @@ class TestHubspotAllFields(HubspotBaseTest):
         cls.expected_records = dict()
 
         # pass
-        # cls.expected_records['campaigns'] = test_client.get_campaigns()
-        # cls.expected_records['forms'] = test_client.get_forms()
-        # cls.expected_records['owners'] = test_client.get_owners()
-        # cls.expected_records['engagements'] = test_client.get_engagements()
-        # cls.expected_records['workflows'] = test_client.get_workflows()
-        # cls.expected_records['email_events'] = test_client.get_email_events()
-        # cls.expected_records['contact_lists'] = test_client.get_contact_lists()
-        #cls.expected_records['contacts'] = test_client.get_contacts()
-        # cls.expected_records['companies'] = test_client.get_companies(since=cls.my_timestamp)
-        # company_ids = [company['companyId'] for company in cls.expected_records['companies']]
-        # cls.expected_records['contacts_by_company'] = test_client.get_contacts_by_company(parent_ids=company_ids)
+        cls.expected_records['campaigns'] = test_client.get_campaigns()
+        cls.expected_records['forms'] = test_client.get_forms()
+        cls.expected_records['owners'] = test_client.get_owners()
+        cls.expected_records['engagements'] = test_client.get_engagements()
+        cls.expected_records['workflows'] = test_client.get_workflows()
+        cls.expected_records['email_events'] = test_client.get_email_events()
+        cls.expected_records['contact_lists'] = test_client.get_contact_lists()
+        cls.expected_records['contacts'] = test_client.get_contacts()
+        cls.expected_records['companies'] = test_client.get_companies(since=cls.my_timestamp)
+        company_ids = [company['companyId'] for company in cls.expected_records['companies']]
+        cls.expected_records['contacts_by_company'] = test_client.get_contacts_by_company(parent_ids=company_ids)
+        cls.expected_records['deal_pipelines'] = test_client.get_deal_pipelines()
         # fail
         # cls.expected_records['subscription_changes'] = test_client.get_subscription_changes()
 
-
-        # cls.expected_records['deals'] = test_client.get_deals() # TODO work with dev to get passing
-
-
-
         # TODO
-        cls.expected_records['deal_pipelines'] = test_client.get_deal_pipelines()
+        # cls.expected_records['deals'] = test_client.get_deals() # TODO work with dev to get passing
 
         for stream, records in cls.expected_records.items():
             print(f"The test client found {len(records)} {stream} records.")


### PR DESCRIPTION
# Description of change
Implement a test client to set expectations. Update the All Fields test assertions to reflect current standards. Increase test coverage to all streams. NOTE: We are currently unable to test the `subscription_changes` stream because it does not have a valid primary key. We did lay out the GET method for this stream for future use after that bug is picked up.
Related Tickets:
https://jira.talendforge.org/browse/TDL-14772
https://jira.talendforge.org/browse/TDL-14760
https://jira.talendforge.org/browse/TDL-14761

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
