### PR TITLE
updated expected records for companies to filter after getall

### DIFF
--- a/tests/client.py
+++ b/tests/client.py
@@ -12,7 +12,7 @@ BASE_URL = "https://api.hubapi.com"
 
 
 class TestClient():
-
+    START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
     V3_DEALS_PROPERTY_PREFIXES = {'hs_date_entered', 'hs_date_exited', 'hs_time_in'}
 
     ##########################################################################
@@ -128,7 +128,7 @@ class TestClient():
         """
         url = f"{BASE_URL}/companies/v2/companies/paged"
         if not isinstance(since, datetime.datetime):
-            since = datetime.datetime.strptime(since, "%Y-%m-%dT%H:%M:%S.%fZ")
+            since = datetime.datetime.strptime(since, self.START_DATE_FORMAT)
         params = {'properties': ["createdate", "hs_lastmodifieddate"]}
         records = []
 

--- a/tests/test_hubspot_all_fields_test.py
+++ b/tests/test_hubspot_all_fields_test.py
@@ -1,7 +1,7 @@
 import tap_tester.connections as connections
 import tap_tester.menagerie   as menagerie
 import tap_tester.runner      as runner
-
+import datetime
 from base import HubspotBaseTest
 from client import TestClient
 
@@ -99,20 +99,13 @@ class TestHubspotAllFields(HubspotBaseTest):
         })
 
     def get_properties(self):
-        return {'start_date' : '2021-08-05T00:00:00Z'}
-
-    # TODO move the overriden start date up as much as possible to minimize the run time
-    #      it can probably be dynamic like today minus 7 days
+        return {'start_date' : '2021-08-05T00:00:00Z'} # TODO make dynamic
 
     @classmethod
     def setUpClass(cls):
         cls.maxDiff = None  # see all output in failure
 
-        # TODO my_timestamp needs to be driven off of start_date
-        # do a strptim on get_prop[start_date]
-        # Then do a strftime using this format with fractional seconds
-        
-        cls.my_timestamp = '2021-08-05T00:00:00.000000Z'
+        cls.my_timestamp = cls.get_properties(cls)['start_date']
 
         test_client = TestClient()
         cls.expected_records = dict()
@@ -141,13 +134,6 @@ class TestHubspotAllFields(HubspotBaseTest):
         conn_id = connections.ensure_connection(self)
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
-
-        # # moving the state up so the sync will be shorter and the test takes less time
-        # state = {'bookmarks': {'companies': {'current_sync_start': None,
-        #                                      'hs_lastmodifieddate': self.my_timestamp,
-        #                                      'offset': {}}},
-        #          'currently_syncing': None}
-        # menagerie.set_state(conn_id, state)
 
         # Select only the expected streams tables
         expected_streams = self.testable_streams()

--- a/tests/test_hubspot_all_fields_test.py
+++ b/tests/test_hubspot_all_fields_test.py
@@ -81,6 +81,8 @@ KNOWN_MISSING_FIELDS = {
         'property_hs_num_associated_deal_splits',
         'property_hs_is_deal_split',
         'stateChanges',
+        'property_hs_num_associated_active_deal_registrations',
+        'property_hs_num_associated_deal_registrations'
     },
 }
 
@@ -96,11 +98,20 @@ class TestHubspotAllFields(HubspotBaseTest):
             'subscription_changes', # BUG_TDL-14938 https://jira.talendforge.org/browse/TDL-14938
         })
 
+    def get_properties(self):
+        return {'start_date' : '2021-08-05T00:00:00Z'}
+
+    # TODO move the overriden start date up as much as possible to minimize the run time
+    #      it can probably be dynamic like today minus 7 days
 
     @classmethod
     def setUpClass(cls):
         cls.maxDiff = None  # see all output in failure
 
+        # TODO my_timestamp needs to be driven off of start_date
+        # do a strptim on get_prop[start_date]
+        # Then do a strftime using this format with fractional seconds
+        
         cls.my_timestamp = '2021-08-05T00:00:00.000000Z'
 
         test_client = TestClient()
@@ -131,12 +142,12 @@ class TestHubspotAllFields(HubspotBaseTest):
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 
-        # moving the state up so the sync will be shorter and the test takes less time
-        state = {'bookmarks': {'companies': {'current_sync_start': None,
-                                             'hs_lastmodifieddate': self.my_timestamp,
-                                             'offset': {}}},
-                 'currently_syncing': None}
-        menagerie.set_state(conn_id, state)
+        # # moving the state up so the sync will be shorter and the test takes less time
+        # state = {'bookmarks': {'companies': {'current_sync_start': None,
+        #                                      'hs_lastmodifieddate': self.my_timestamp,
+        #                                      'offset': {}}},
+        #          'currently_syncing': None}
+        # menagerie.set_state(conn_id, state)
 
         # Select only the expected streams tables
         expected_streams = self.testable_streams()


### PR DESCRIPTION
# Description of change
Companies stream was not getting the correct expected records because we were using recent companies API instead of getting all companies, then filtering.
# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
