### PR TITLE
move start date to reflect changing test data

### DIFF
--- a/tests/test_hubspot_start_date.py
+++ b/tests/test_hubspot_start_date.py
@@ -150,7 +150,7 @@ class TestHubspotStartDateStatic(TestHubspotStartDate):
 
         else:
             return {
-                'start_date' : '2021-08-19T00:00:00Z'
+                'start_date' : '2022-02-11T00:00:00Z'
             }
 
     def setUp(self):


### PR DESCRIPTION
# Description of change
The records for our `owners` in the tap-hubspot account were updated causing a failing test. 
`(tap-tester) vagrant@vagrant:/opt/code/tap-tester$ jq 'select(.table_name == "owners") | .messages[].data.updatedAt' /tmp/tap-tester-target-out.json
"2022-02-11T16:11:14.058000Z"
"2021-12-10T16:21:40.778000Z"`
We moved the start date forward to maintain test coverage for the failing `owners` stream.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
