### PR TITLE
Comment out Address Field on form create

### DIFF
--- a/tests/client.py
+++ b/tests/client.py
@@ -1066,39 +1066,38 @@ class TestClient():
                     "default": True,
                     "isSmartGroup": False
                 },
-                {
-                    "fields": [
-                        {
-                            "name": "adress_1",
-                            "label": "Adress 1",
-                            "type": "string",
-                            "fieldType": "text",
-                            "description": "",
-                            "groupName": "",
-                            "displayOrder": 2,
-                            "required": False,
-                            "selectedOptions": [],
-                            "options": [],
-                            "validation": {
-                                "name": "",
-                                "message": "",
-                                "data": "",
-                                "useDefaultBlockList": False
-                            },
-                            "enabled": True,
-                            "hidden": False,
-                            "defaultValue": "",
-                            "isSmartField": False,
-                            "unselectedLabel": "",
-                            "placeholder": ""
-                        }
-                    ],
-                    "default": True,
-                    "isSmartGroup": False
-                }
+                # KDS: Removed due to INVALID_FORM_FIELDS error.
+                # {
+                #     "fields": [
+                #         {
+                #             "name": "adress_1",
+                #             "label": "Adress 1",
+                #             "type": "string",
+                #             "fieldType": "text",
+                #             "description": "",
+                #             "groupName": "",
+                #             "displayOrder": 2,
+                #             "required": False,
+                #             "selectedOptions": [],
+                #             "options": [],
+                #             "validation": {
+                #                 "name": "",
+                #                 "message": "",
+                #                 "data": "",
+                #                 "useDefaultBlockList": False
+                #             },
+                #             "enabled": True,
+                #             "hidden": False,
+                #             "defaultValue": "",
+                #             "isSmartField": False,
+                #             "unselectedLabel": "",
+                #             "placeholder": ""
+                #         }
+                #     ],
+                #     "default": True,
+                #     "isSmartGroup": False
+                # }
             ],
-            "createdAt": 1318534279910,
-            "updatedAt": 1413919291011,
             "performableHtml": "",
             "migratedFrom": "ld",
             "ignoreCurrentValues": False,


### PR DESCRIPTION
# Description of change
Adjust CRUD client method in tests. The `forms` address field was causing a 400 error. It is no longer supported by the v2 endpoint we are hitting.

# Manual QA steps
 - Ran client_tester.py locally to confirm root cause was the `create_forms` method. Test passing.
 
# Risks
 - None, test client change.
 
# Rollback steps
 - revert this branch
