### PR TITLE
skip new property field for contacts stream

### DIFF
--- a/tests/test_hubspot_all_fields.py
+++ b/tests/test_hubspot_all_fields.py
@@ -32,7 +32,8 @@ KNOWN_MISSING_FIELDS = {
         'property_hs_latest_source_data_2',
         'property_hs_latest_source',
         'property_hs_latest_source_data_1',
-        'property_hs_timezone'
+        'property_hs_timezone',
+        'property_hs_latest_source_timestamp',
     },
     'contact_lists': {  # BUG https://jira.talendforge.org/browse/TDL-14996
         'authorId',


### PR DESCRIPTION
# Description of change
Skipping newly returned `property_hs_latest_source_timestamp` field on `contacts` stream
# Manual QA steps
 - Updated linked jira ticket 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
