### PR TITLE
Qa/all fields failure companies

### DIFF
--- a/tests/test_hubspot_all_fields.py
+++ b/tests/test_hubspot_all_fields.py
@@ -91,6 +91,10 @@ KNOWN_MISSING_FIELDS = {
         'stateChanges',
         'isDeleted',
         'additionalDomains',
+        'property_hs_analytics_latest_source',
+        'property_hs_analytics_latest_source_data_2',
+        'property_hs_analytics_latest_source_data_1',
+        'property_hs_analytics_latest_source_timestamp',
     },
     'campaigns': {  # BUG https://jira.talendforge.org/browse/TDL-15003
         'lastProcessingStateChangeAt',


### PR DESCRIPTION
# Description of change
Skip newly returned fields for `companies` stream in All Fields test.
```
        'property_hs_analytics_latest_source',
        'property_hs_analytics_latest_source_data_2',
        'property_hs_analytics_latest_source_data_1',
        'property_hs_analytics_latest_source_timestamp',
```
# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
