### PR TITLE
Resolve All field test case error.

### DIFF
--- a/tests/test_hubspot_all_fields.py
+++ b/tests/test_hubspot_all_fields.py
@@ -95,6 +95,7 @@ KNOWN_MISSING_FIELDS = {
         'customUid',
         'isPublished',
         'paymentSessionTemplateIds',
+        'selectedExternalOptions'
     },
     'companies': {  # BUG https://jira.talendforge.org/browse/TDL-15003
         'mergeAudits',


### PR DESCRIPTION
# Description of change
- `selectedExternalOptions` field is returned by API response but is not available in the schema of the `forms` stream. 
  - That's why CCI build started to fail. ([build1](https://app.circleci.com/pipelines/github/singer-io/tap-hubspot/1081/workflows/bc8b09b7-761f-4502-b4a0-c1718624a9fc), [build2](https://app.circleci.com/pipelines/github/singer-io/tap-hubspot/1081/workflows/bc8b09b7-761f-4502-b4a0-c1718624a9fc))
- Added `selectedExternalOptions` field into `KNOWN_MISSING_FIELDS` map to pass all field test case.


# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
