### PR TITLE
Utilize bookmark of existing connection

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -628,9 +628,11 @@ def sync_deals(STATE, ctx):
 
     bookmark_field_in_record = 'hs_lastmodifieddate'
 
-    # Tap was used to write bookmark using replication key `hs_lastmodifieddate`. 
-    # Now, as the replication key gets changed to "property_hs_lastmodifieddate", `get_start` function would return 
-    # bookmark value of older bookmark key(`hs_lastmodifieddate`) if it is available. 
+    # Tap was used to write bookmark using replication key `hs_lastmodifieddate`.
+    # Now, as the replication key gets changed to "property_hs_lastmodifieddate", `get_start` function would return
+    # bookmark value of older bookmark key(`hs_lastmodifieddate`) if it is available.
+    # So, here `older_bookmark_key` is the previous bookmark key that may be available in the state of
+    # the existing connection.
 
     start = utils.strptime_with_tz(get_start(STATE, "deals", bookmark_key, older_bookmark_key=bookmark_field_in_record))
     max_bk_value = start
@@ -687,8 +689,6 @@ def sync_deals(STATE, ctx):
             if not modified_time or modified_time >= start:
                 record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
                 singer.write_record("deals", record, catalog.get('stream_alias'), time_extracted=utils.now())
-
-    STATE = singer.clear_bookmark(STATE, 'deals', 'hs_lastmodifieddate')
 
     STATE = singer.write_bookmark(STATE, 'deals', bookmark_key, utils.strftime(max_bk_value))
     singer.write_state(STATE)

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -673,6 +673,9 @@ def sync_deals(STATE, ctx):
                 record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
                 singer.write_record("deals", record, catalog.get('stream_alias'), time_extracted=utils.now())
 
+    # Clear bookmark for existing connections that are using `hs_lastmodifieddate` as replication key.
+    STATE = singer.clear_bookmark(STATE, 'deals', 'hs_lastmodifieddate')
+
     STATE = singer.write_bookmark(STATE, 'deals', bookmark_key, utils.strftime(max_bk_value))
     singer.write_state(STATE)
     return STATE

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -102,7 +102,11 @@ def get_start(state, tap_stream_id, bookmark_key, older_bookmark_key=None):
     """
     If the current bookmark_key is available in the state, then return the bookmark_key value.
     If it is not available then check and return the older_bookmark_key in the state for the existing connection.
-    If non of the key available in the state for a particular stream, then return start_date.
+    If none of the keys are available in the state for a particular stream, then return start_date.
+
+    We have made this change because of an update in the replication key of the deals stream.
+    So, if any existing connections have only older_bookmark_key in the state then tap should utilize that bookmark value.
+    Then next time, the tap should use the current bookmark value.
     """
     current_bookmark = singer.get_bookmark(state, tap_stream_id, bookmark_key)
     if current_bookmark is None:
@@ -626,7 +630,7 @@ def sync_deals(STATE, ctx):
     # prefix `property_` along with each field.
     # That's why bookmark_key is `property_hs_lastmodifieddate` so that we can mark it as automatic inclusion.
 
-    bookmark_field_in_record = 'hs_lastmodifieddate'
+    last_modified_date = 'hs_lastmodifieddate'
 
     # Tap was used to write bookmark using replication key `hs_lastmodifieddate`.
     # Now, as the replication key gets changed to "property_hs_lastmodifieddate", `get_start` function would return
@@ -634,7 +638,7 @@ def sync_deals(STATE, ctx):
     # So, here `older_bookmark_key` is the previous bookmark key that may be available in the state of
     # the existing connection.
 
-    start = utils.strptime_with_tz(get_start(STATE, "deals", bookmark_key, older_bookmark_key=bookmark_field_in_record))
+    start = utils.strptime_with_tz(get_start(STATE, "deals", bookmark_key, older_bookmark_key=last_modified_date))
     max_bk_value = start
     LOGGER.info("sync_deals from %s", start)
     most_recent_modified_time = start
@@ -675,9 +679,9 @@ def sync_deals(STATE, ctx):
         for row in gen_request(STATE, 'deals', url, params, 'deals', "hasMore", ["offset"], ["offset"], v3_fields=v3_fields):
             row_properties = row['properties']
             modified_time = None
-            if bookmark_field_in_record in row_properties:
+            if last_modified_date in row_properties:
                 # Hubspot returns timestamps in millis
-                timestamp_millis = row_properties[bookmark_field_in_record]['timestamp'] / 1000.0
+                timestamp_millis = row_properties[last_modified_date]['timestamp'] / 1000.0
                 modified_time = datetime.datetime.fromtimestamp(timestamp_millis, datetime.timezone.utc)
             elif 'createdate' in row_properties:
                 # Hubspot returns timestamps in millis

--- a/tap_hubspot/tests/unittests/test_get_start.py
+++ b/tap_hubspot/tests/unittests/test_get_start.py
@@ -1,0 +1,94 @@
+import unittest
+import tap_hubspot
+from tap_hubspot import get_start
+from tap_hubspot import singer
+
+def get_state(key,value):
+    """
+    Returns a mock state
+    """
+    return {
+        "bookmarks": {
+            "stream_id_1": {
+                "offset": {},
+                key: value
+                }
+            }
+        }
+
+class TestGetStart(unittest.TestCase):
+    """
+    Verify return value of `get_start` function.
+    """
+    def test_get_start_without_state(self):
+        """
+        This test verifies that `get_start` function returns start_date from CONFIG
+        if an empty state is passed.
+        """
+        mock_state = {}
+        expected_value = tap_hubspot.CONFIG["start_date"]
+        returned_value = get_start(mock_state, "stream_id_1", "current_bookmark", "old_bookmark")
+
+        # Verify that returned value is start_date
+        self.assertEqual(returned_value, expected_value)
+
+    def test_get_start_with_old_bookmark(self):
+        """
+        This test verifies that the `get_start` function returns old_bookmark from the state
+        if current_bookmark is not available in the state.
+        """
+        mock_state = get_state("old_bookmark", "OLD_BOOKMARK_VALUE")
+        expected_value = "OLD_BOOKMARK_VALUE"
+
+        returned_value = get_start(mock_state, "stream_id_1", "current_bookmark", "old_bookmark")
+
+        # Verify that returned value is old_bookmark_value
+        self.assertEqual(returned_value, expected_value)
+
+    def test_get_start_with_current_bookmark(self):
+        """
+        This test verifies that the `get_start` function returns current_bookmark from the state
+        if current_bookmark is available in the state.
+        """
+        mock_state = get_state("current_bookmark", "CURR_BOOKMARK_VALUE")
+        expected_value = "CURR_BOOKMARK_VALUE"
+
+        returned_value = get_start(mock_state, "stream_id_1", "current_bookmark", "old_bookmark")
+
+        # Verify that returned value is current bookmark
+        self.assertEqual(returned_value, expected_value)
+
+    def test_get_start_with_no_old_bookmark(self):
+        """
+        This test verifies that the `get_start` function returns start_date from CONFIG
+        if an empty state is passed and old_bookamrk is not given.
+        """
+        mock_state = {}
+        expected_value = tap_hubspot.CONFIG["start_date"]
+
+        returned_value = get_start(mock_state, "stream_id_1", "current_bookmark")
+
+        # Verify that returned value is start_date
+        self.assertEqual(returned_value, expected_value)
+
+    def test_get_start_with_both_bookmark(self):
+        """
+        This test verifies that the `get_start` function returns current_bookmark from the state
+        if both old and current bookmark is available in the state.
+        """
+
+        mock_state = {
+            "bookmarks": {
+                "stream_id_1": {
+                    "offset": {},
+                    "old_bookmark": "OLD_BOOKMARK_VALUE",
+                    "current_bookmark": "CURR_BOOKMARK_VALUE"
+                    }
+                }
+            }
+        expected_value = "CURR_BOOKMARK_VALUE"
+
+        returned_value = get_start(mock_state, "stream_id_1", "current_bookmark", "old_bookmark")
+
+        # Verify that returned value is current bookmark
+        self.assertEqual(returned_value, expected_value)

--- a/tap_hubspot/tests/unittests/test_get_start.py
+++ b/tap_hubspot/tests/unittests/test_get_start.py
@@ -45,20 +45,20 @@ class TestGetStart(unittest.TestCase):
         # Verify that returned value is old_bookmark_value
         self.assertEqual(returned_value, expected_value)
 
-    def test_get_start_with_current_bookmark(self):
+    def test_get_start_with_current_bookmark_and_no_old_bookmark(self):
         """
         This test verifies that the `get_start` function returns current_bookmark from the state
-        if current_bookmark is available in the state.
+        if current_bookmark is available in the state and old_bookmark is not given.
         """
         mock_state = get_state("current_bookmark", "CURR_BOOKMARK_VALUE")
         expected_value = "CURR_BOOKMARK_VALUE"
 
-        returned_value = get_start(mock_state, "stream_id_1", "current_bookmark", "old_bookmark")
+        returned_value = get_start(mock_state, "stream_id_1", "current_bookmark")
 
         # Verify that returned value is current bookmark
         self.assertEqual(returned_value, expected_value)
 
-    def test_get_start_with_no_old_bookmark(self):
+    def test_get_start_with_empty_start__no_old_bookmark(self):
         """
         This test verifies that the `get_start` function returns start_date from CONFIG
         if an empty state is passed and old_bookamrk is not given.


### PR DESCRIPTION
# Description of change

To use bookmark of existing connection we have updated code as below,

- Updated get_start function to use older bookmark key value if it is available for any existing connection.
  - If the current bookmark_key is available in the state, then get_start returns the bookmark_key value.
  - If it is not available then check and return the older_bookmark_key(if it is available) in the state for the existing connection.
  - If non of the key available in the state for a particular stream, then return start_date.
- Added unit test cases for the get_start function.

**Note**: We will not clear out existing bookmarks from the state. Instead, we will keep both bookmark values older and newer. 
# Manual QA steps
 - Run the sync mode without state and verify that the state file contains only property_hs_lastmodifieddate.
 - Run the sync mode with the state file(contains only hs_lastmodifieddate) and verify that the state file contains both hs_lastmodifieddate and property_hs_lastmodifieddate.
    - Also, verify that tap retrieves records based on hs_lastmodifieddate.
 - Run the sync mode with the state file(contains both hs_lastmodifieddate and property_hs_lastmodifieddate) and verify that the state file contains both hs_lastmodifieddate and property_hs_lastmodifieddate. 
   - Also, verify that tap retrieves records based on property_hs_lastmodifieddate.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
