### PR TITLE
Update replication key in companies stream

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -72,7 +72,7 @@ class HubspotBaseTest(unittest.TestCase):
             "companies": {
                 self.PRIMARY_KEYS: {"companyId"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"hs_lastmodifieddate"},
+                self.REPLICATION_KEYS: {"property_hs_lastmodifieddate"},
                 self.EXPECTED_PAGE_SIZE: 250,
                 self.OBEYS_START_DATE: True
             },

--- a/tests/test_hubspot_automatic_fields.py
+++ b/tests/test_hubspot_automatic_fields.py
@@ -69,7 +69,7 @@ class TestHubspotAutomaticFields(HubspotBaseTest):
                 expected_keys = self.expected_automatic_fields().get(stream)
 
                 # BUG_TDL-9939 https://jira.talendforge.org/browse/TDL-9939 Replication keys are not included as an automatic field for these streams
-                if stream in {'companies', 'subscription_changes', 'email_events'}:
+                if stream in {'subscription_changes', 'email_events'}:
                     # replication keys not in the expected_keys
                     remove_keys = self.expected_metadata()[stream].get(self.REPLICATION_KEYS)
                     expected_keys = expected_keys.difference(remove_keys)

--- a/tests/test_hubspot_discovery.py
+++ b/tests/test_hubspot_discovery.py
@@ -91,7 +91,7 @@ class DiscoveryTest(HubspotBaseTest):
                     "metadata", {self.REPLICATION_METHOD: None}).get(self.REPLICATION_METHOD)
                 if stream_properties[0].get(
                         "metadata", {self.REPLICATION_KEYS: []}).get(self.REPLICATION_KEYS, []):
-                    
+            
                     if stream in ["contacts", "companies", "deals"]:
                         self.assertTrue(actual_replication_method == self.INCREMENTAL,
                                     msg="Expected INCREMENTAL replication "

--- a/tests/test_hubspot_discovery.py
+++ b/tests/test_hubspot_discovery.py
@@ -91,8 +91,8 @@ class DiscoveryTest(HubspotBaseTest):
                     "metadata", {self.REPLICATION_METHOD: None}).get(self.REPLICATION_METHOD)
                 if stream_properties[0].get(
                         "metadata", {self.REPLICATION_KEYS: []}).get(self.REPLICATION_KEYS, []):
-              
-                    if stream == "contacts":
+                    
+                    if stream in ["contacts", "companies", "deals"]:
                         self.assertTrue(actual_replication_method == self.INCREMENTAL,
                                     msg="Expected INCREMENTAL replication "
                                     "since there is a replication key")
@@ -114,7 +114,7 @@ class DiscoveryTest(HubspotBaseTest):
                 actual_automatic_fields = {item.get("breadcrumb", ["properties", None])[1]
                                            for item in metadata
                                            if item.get("metadata").get("inclusion") == "automatic"}
-                if stream == "contacts":
+                if stream in ["contacts", "companies", "deals"]:
                     self.assertEqual(expected_automatic_fields,
                                     actual_automatic_fields,
                                     msg=f"expected {expected_automatic_fields} automatic fields but got {actual_automatic_fields}"

--- a/tests/test_hubspot_start_date.py
+++ b/tests/test_hubspot_start_date.py
@@ -117,7 +117,7 @@ class TestHubspotStartDate(HubspotBaseTest):
                         # BUG_TDL-9939 replication key is not listed correctly
                         if stream in {"campaigns", "companies", "contacts_by_company", "deal_pipelines", "deals"}:
                             # For deals stream, the replication key is already prefixed with 'property_'.
-                            replication_key =  [replication_key[0]] if stream=="deals" else [f'property_{replication_key[0]}']
+                            replication_key =  [replication_key[0]] if stream in ["deals", "companies"] else [f'property_{replication_key[0]}']
                             first_sync_replication_key_values = [record['data'][replication_key[0]]['value']
                                                                  for record in first_sync_messages]
                             second_sync_replication_key_values = [record['data'][replication_key[0]]['value']


### PR DESCRIPTION
# Description of change
- Replaced replication key of `companies` stream with `property_hs_lastmodifieddate` field.
- Updated replication method of `companies` stream in the tap to `INCREMENTAL`.
- Updated replication key in the `base.py` of tap-tester.
- Updated `automatic_field` and `start_date` tap tester test case.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
