### PR TITLE
fix test client post for engagments

### DIFF
--- a/tests/client.py
+++ b/tests/client.py
@@ -7,8 +7,7 @@ import json
 import uuid
 import random
 
-from tap_tester import menagerie
-from tap_tester.logger import LOGGER
+from tap_tester import menagerie, LOGGER
 
 from base import HubspotBaseTest
 
@@ -69,7 +68,7 @@ class TestClient():
 
         if response.status_code == 204:
 
-            LOGGER.warn(f"TEST CLIENT | WARNING Response is empty")
+            LOGGER.warn(f"TEST CLIENT Response is empty")
             # NB: There is a simplejson.scanner.JSONDecodeError thrown when we attempt
             #     to do a response.json() on a 204 response. To get around this we just return an empty list
             #     as we assume that a 204 will not have body. A better implementation would be to catch the
@@ -954,10 +953,17 @@ class TestClient():
     def create_engagements(self):
         """
         HubSpot API https://legacydocs.hubspot.com/docs/methods/engagements/create_engagement
-        NB: Dependent on valid (currently hardcoded) contactId, companyId, and ownerId.
+        NB: Dependent on valid (currently hardcoded) companyId, and ownerId.
             THIS IS A POTENTIAL POINT OF INSTABILITY FOR THE TESTS
         """
         record_uuid = str(uuid.uuid4()).replace('-', '')
+
+        # gather all contacts and randomly choose one that has not hit the limit
+        contact_records = self.get_contacts()
+        contact_ids = [contact['vid']
+                       for contact in contact_records
+                       if contact['vid'] != 2304] # contact 2304 has hit the 10,000 assoc limit
+        contact_id = random.choice(contact_ids)
 
         url = f"{BASE_URL}/engagements/v1/engagements"
         data = {
@@ -968,7 +974,7 @@ class TestClient():
                 "timestamp": 1409172644778
             },
             "associations": {
-                "contactIds": [2304],
+                "contactIds": [contact_id],
                 "companyIds": [6804176293],
                 "dealIds": [ ],
                 "ownerIds": [ ],

--- a/tests/client_tester.py
+++ b/tests/client_tester.py
@@ -4,7 +4,12 @@ from client import TestClient
 from base import HubspotBaseTest
 
 class TestHubspotTestClient(HubspotBaseTest):
-    """Test the basic functionality of our Test Client. This is a tool for sanity checks, nothing more."""
+    """
+    Test the basic functionality of our Test Client. This is a tool for sanity checks, nothing more.
+
+    To check an individual crud method, uncomment the corresponding test case below, and execute this file
+    as if it is a normal tap-tester test via bin/run-test.
+    """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.test_client = TestClient(self.get_properties()['start_date'])
@@ -73,14 +78,14 @@ class TestHubspotTestClient(HubspotBaseTest):
     #         f"Before post found {len(old_records)} records. After post found {len(new_records)} records"
 
 
-    def test_deal_pipelines_create(self):
-        # Testing deal_pipelines POST
+    # def test_deal_pipelines_create(self):
+    #     # Testing deal_pipelines POST
 
-        old_records = self.test_client.get_deal_pipelines()
-        our_record = self.test_client.create_deal_pipelines()
-        new_records = self.test_client.get_deal_pipelines()
-        assert len(old_records) < len(new_records), \
-            f"Before post found {len(old_records)} records. After post found {len(new_records)} records"
+    #     old_records = self.test_client.get_deal_pipelines()
+    #     our_record = self.test_client.create_deal_pipelines()
+    #     new_records = self.test_client.get_deal_pipelines()
+    #     assert len(old_records) < len(new_records), \
+    #         f"Before post found {len(old_records)} records. After post found {len(new_records)} records"
 
     # def test_deal_pipelines_deletes(self):
     #     # Testing deal_pipelines DELETE


### PR DESCRIPTION
# Description of change
Fix the engagements post method in the test client by dynamically grabbing a contact id to make an association on. 

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
