### PR TITLE
Fix contacts sync

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -500,8 +500,10 @@ def sync_contacts(STATE, ctx):
 
             if not modified_time or modified_time >= start:
                 vids.append(row['vid'])
-                # Adding replication key value in `bookmark_values` dict
-                # Here, key is vid(primary key) and value is replication key value.
+
+            # Adding replication key value in `bookmark_values` dict
+            # Here, key is vid(primary key) and value is replication key value.
+            if modified_time:
                 bookmark_values[row['vid']] = utils.strftime(modified_time)
 
             if modified_time and modified_time >= max_bk_value:

--- a/tests/unittests/test_contacts.py
+++ b/tests/unittests/test_contacts.py
@@ -1,0 +1,72 @@
+import os
+import unittest
+from tap_hubspot import acquire_access_token_from_refresh_token
+from tap_hubspot import CONFIG
+from tap_hubspot import Context
+from tap_hubspot import gen_request
+from tap_hubspot import get_url
+from tap_hubspot import load_schema
+from tap_hubspot import merge_responses
+from tap_hubspot import process_v3_deals_records
+from tap_hubspot import sync_contacts
+from unittest import mock
+
+import logging
+logging.getLogger().level = logging.INFO
+
+
+class TestContacts(unittest.TestCase):
+
+    def setUp(self):
+        self.maxDiff = None
+
+    @mock.patch("singer.write_record")
+    @mock.patch("tap_hubspot.request")
+    @mock.patch("tap_hubspot.gen_request")
+    @mock.patch("tap_hubspot.load_schema")
+    def test_bookmarking(self, fake_load_schema, fake_gen_request, fake_request, fake_write_record):
+        self.maxDiff = None
+        state = {
+            "bookmarks": {
+                "contacts": {
+                    "updated_at": "2022-09-26T00:00:00Z"
+                }
+            }
+        }
+        state = {
+            "bookmarks": {
+                "contacts": {
+                    "versionTimestamp": "2022-09-26T00:00:00Z"}
+                },
+
+        }
+        catalog = {"streams": [
+            {"tap_stream_id": "contacts",
+             "metadata": [],
+             "schema": {}}
+        ]}
+        ctx = Context(catalog)
+
+        fake_load_schema.return_value = {}
+        fake_gen_request.return_value = [
+            {"vid": 1},
+            {"vid": 2},
+            {"vid": 3, "versionTimestamp": "2022-09-26T12:00:00Z"},
+        ]
+
+        fake_request.return_value.json.return_value.values.return_value = [
+            {"vid": 1},
+            {"vid": 2},
+            {"vid": 3},
+        ]
+
+        sync_contacts(state, ctx)
+        actual = [x[0][1] for x in fake_write_record.call_args_list]
+
+        expected = [
+            {'vid': 1, 'versionTimestamp': None},
+            {'vid': 2, 'versionTimestamp': None},
+            {'vid': 3, 'versionTimestamp': '2022-09-26T12:00:00.000000Z'}
+        ]
+
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
# Description of change
This PR fixes what appears to be a bug from #192.

Here is the stacktrace
```python
CRITICAL 'NoneType' object has no attribute 'utcoffset'
Traceback (most recent call last):
  File "/usr/local/share/virtualenvs/tap-hubspot/bin/tap-hubspot", line 33, in <module>
    sys.exit(load_entry_point('tap-hubspot', 'console_scripts', 'tap-hubspot')())
  File "/home/vagrant/git/tap-hubspot/tap_hubspot/__init__.py", line 1164, in main
    raise exc
  File "/home/vagrant/git/tap-hubspot/tap_hubspot/__init__.py", line 1161, in main
    main_impl()
  File "/home/vagrant/git/tap-hubspot/tap_hubspot/__init__.py", line 1155, in main_impl
    do_sync(STATE, args.properties)
  File "/home/vagrant/git/tap-hubspot/tap_hubspot/__init__.py", line 1040, in do_sync
    STATE = stream.sync(STATE, ctx) # pylint: disable=not-callable
  File "/home/vagrant/git/tap-hubspot/tap_hubspot/__init__.py", line 505, in sync_contacts
    bookmark_values[row['vid']] = utils.strftime(modified_time)
  File "/usr/local/share/virtualenvs/tap-hubspot/lib/python3.9/site-packages/singer/utils.py", line 41, in strftime
    if dtime.utcoffset() != datetime.timedelta(0):
AttributeError: 'NoneType' object has no attribute 'utcoffset'
```

---

## Diagnosis

The sync code flow seems to be using `sync_contact_vids` in order to collect a page of `vid`s from the `/contacts/v1/lists/all/contacts/all` endpoint. 

Those get passed off to `_sync_contact_vids` in order to be sent to the `/contacts/v1/contact/vids/batch` endpoint to get more details for specific `vid`s.

The bug seems to be that we assume every object in the first response has a `versionTimestamp` key. So when we initialize `modified_time = None` on Line 494, nothing gives it a new value before we try `bookmark_values[row['vid']] = utils.strftime(modified_time)`, leading to our stack trace

## Rationale for change

I saw [this line](https://github.com/singer-io/tap-hubspot/blob/df65433e17e4d5a665f87cb00bd7cf226c1560d7/tap_hubspot/__init__.py#L466) in `_sync_contact_vids` which makes me think that we don't always expect `bookmark_values` to have the `vid`. So the change in this PR is to not convert the a value to a datetime when we don't have a value.


# Manual QA steps
 - I wrote a unit test that reproduces the stack trace on `master`
 - The test mocks the response of the first endpoint to return records that have and don't have a `versionTimestamp`. Then it mocks the second response to be super minimal. The actual test is that records in the second response are supplemented with the `versionTimestamp` of the first response, if we have it.
 
# Risks
 - Low: The first API response seems to get paginated in full, so we shouldn't miss data from it. Now if you have a `versionTimestamp`, it gets attached to the objects in the second response instead of killing the tap.
     - It makes you wonder if this `versionTimestamp` is the right choice as a replication key though since it can be null.
 
# Rollback steps
 - revert this branch
