### PR TITLE
Refresh the access token after certain interval of time within integration tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -75,14 +75,14 @@ class HubspotBaseTest(BaseCase):
                 self.PRIMARY_KEYS: {"companyId"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"property_hs_lastmodifieddate"},
-                self.EXPECTED_PAGE_SIZE: 250,
+                self.EXPECTED_PAGE_SIZE: 100,
                 self.OBEYS_START_DATE: True
             },
             "contact_lists": {
                 self.PRIMARY_KEYS: {"listId"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"updatedAt"},
-                self.EXPECTED_PAGE_SIZE: 250,
+                self.EXPECTED_PAGE_SIZE: 100,
                 self.OBEYS_START_DATE: True
             },
             "contacts": {
@@ -121,7 +121,7 @@ class HubspotBaseTest(BaseCase):
                 self.PRIMARY_KEYS: {"engagement_id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"lastUpdated"},
-                self.EXPECTED_PAGE_SIZE: 250,
+                self.EXPECTED_PAGE_SIZE: 100,
                 self.OBEYS_START_DATE: True
             },
             "forms": {

--- a/tests/base.py
+++ b/tests/base.py
@@ -75,14 +75,14 @@ class HubspotBaseTest(BaseCase):
                 self.PRIMARY_KEYS: {"companyId"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"property_hs_lastmodifieddate"},
-                self.EXPECTED_PAGE_SIZE: 100,
+                self.EXPECTED_PAGE_SIZE: 250,
                 self.OBEYS_START_DATE: True
             },
             "contact_lists": {
                 self.PRIMARY_KEYS: {"listId"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"updatedAt"},
-                self.EXPECTED_PAGE_SIZE: 100,
+                self.EXPECTED_PAGE_SIZE: 250,
                 self.OBEYS_START_DATE: True
             },
             "contacts": {
@@ -121,7 +121,7 @@ class HubspotBaseTest(BaseCase):
                 self.PRIMARY_KEYS: {"engagement_id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"lastUpdated"},
-                self.EXPECTED_PAGE_SIZE: 100,
+                self.EXPECTED_PAGE_SIZE: 250,
                 self.OBEYS_START_DATE: True
             },
             "forms": {

--- a/tests/client.py
+++ b/tests/client.py
@@ -295,7 +295,7 @@ class TestClient():
 
 
         if since == 'all':
-            params = {}
+            params = {'count': 250}
         else:
             if not since:
                 since = self.start_date_strf
@@ -304,7 +304,7 @@ class TestClient():
                 since = datetime.datetime.strptime(since, self.START_DATE_FORMAT)
 
             since = str(since.timestamp() * 1000).split(".")[0]
-            params = {'since': since}
+            params = {'since': since, 'count': 250}
 
         records = []
         replication_key = list(self.replication_keys['contact_lists'])[0]
@@ -553,7 +553,7 @@ class TestClient():
         """
         url = f"{BASE_URL}/engagements/v1/engagements/paged"
         replication_key = list(self.replication_keys['engagements'])[0]
-        params = dict()
+        params = {'limit': 250}
         records = []
 
         has_more = True

--- a/tests/client.py
+++ b/tests/client.py
@@ -180,7 +180,6 @@ class TestClient():
         # Resets the access_token if the expiry time is less than or equal to the current time
         if self.CONFIG["token_expires"] <= datetime.datetime.utcnow():
             self.acquire_access_token_from_refresh_token()
-            self.HEADERS = {'Authorization': f"Bearer {self.CONFIG['access_token']}"}
 
         if stream == 'forms':
             return self.get_forms()
@@ -666,7 +665,6 @@ class TestClient():
         # Resets the access_token if the expiry time is less than or equal to the current time
         if self.CONFIG["token_expires"] <= datetime.datetime.utcnow():
             self.acquire_access_token_from_refresh_token()
-            self.HEADERS = {'Authorization': f"Bearer {self.CONFIG['access_token']}"}
 
         if stream == 'forms':
             return self.create_forms()
@@ -1237,7 +1235,6 @@ class TestClient():
         # Resets the access_token if the expiry time is less than or equal to the current time
         if self.CONFIG["token_expires"] <= datetime.datetime.utcnow():
             self.acquire_access_token_from_refresh_token()
-            self.HEADERS = {'Authorization': f"Bearer {self.CONFIG['access_token']}"}
             
         if stream == 'companies':
             return self.update_companies(record_id)
@@ -1551,6 +1548,7 @@ class TestClient():
         self.CONFIG['token_expires'] = (
             datetime.datetime.utcnow() +
             datetime.timedelta(seconds=auth['expires_in'] - 600))
+        self.HEADERS = {'Authorization': f"Bearer {self.CONFIG['access_token']}"}
         LOGGER.info(f"TEST CLIENT | Token refreshed. Expires at {self.CONFIG['token_expires']}")
 
     def __init__(self, start_date=''):
@@ -1565,8 +1563,6 @@ class TestClient():
         ).timestamp() * 1000
 
         self.acquire_access_token_from_refresh_token()
-        self.HEADERS = {'Authorization': f"Bearer {self.CONFIG['access_token']}"}
-
 
         contact_lists_records = self.get_contact_lists(since='all')
         deal_pipelines_records = self.get_deal_pipelines()

--- a/tests/client.py
+++ b/tests/client.py
@@ -176,6 +176,12 @@ class TestClient():
     ### GET
     ##########################################################################
     def read(self, stream, parent_ids=[], since=''):
+
+        # Resets the access_token if the expiry time is less than or equal to the current time
+        if self.CONFIG["token_expires"] <= datetime.datetime.utcnow():
+            self.acquire_access_token_from_refresh_token()
+            self.HEADERS = {'Authorization': f"Bearer {self.CONFIG['access_token']}"}
+
         if stream == 'forms':
             return self.get_forms()
         elif stream == 'owners':
@@ -656,6 +662,12 @@ class TestClient():
 
     def create(self, stream, company_ids=[], subscriptions=[], times=1):
         """Dispatch create to make tests clean."""
+
+        # Resets the access_token if the expiry time is less than or equal to the current time
+        if self.CONFIG["token_expires"] <= datetime.datetime.utcnow():
+            self.acquire_access_token_from_refresh_token()
+            self.HEADERS = {'Authorization': f"Bearer {self.CONFIG['access_token']}"}
+
         if stream == 'forms':
             return self.create_forms()
         elif stream == 'owners':
@@ -1221,6 +1233,12 @@ class TestClient():
     ##########################################################################
 
     def update(self, stream, record_id):
+
+        # Resets the access_token if the expiry time is less than or equal to the current time
+        if self.CONFIG["token_expires"] <= datetime.datetime.utcnow():
+            self.acquire_access_token_from_refresh_token()
+            self.HEADERS = {'Authorization': f"Bearer {self.CONFIG['access_token']}"}
+            
         if stream == 'companies':
             return self.update_companies(record_id)
         elif stream == 'contacts':

--- a/tests/client.py
+++ b/tests/client.py
@@ -1469,6 +1469,11 @@ class TestClient():
     ### Deletes
     ##########################################################################
     def cleanup(self, stream, records, count=10):
+
+        # Resets the access_token if the expiry time is less than or equal to the current time
+        if self.CONFIG["token_expires"] <= datetime.datetime.utcnow():
+            self.acquire_access_token_from_refresh_token()
+            
         if stream == 'deal_pipelines':
             self.delete_deal_pipelines(records, count)
         elif stream == 'contact_lists':

--- a/tests/test_hubspot_pagination.py
+++ b/tests/test_hubspot_pagination.py
@@ -57,6 +57,7 @@ class TestHubspotPagination(HubspotBaseTest):
                 existing_records[stream] = test_client.read(stream)
 
             # check if we exceed the pagination limit
+            LOGGER.info(f"Pagination limit set to - {limits[stream]} and total number of existing record - {len(existing_records[stream])}")
             under_target = limits[stream] + 1 - len(existing_records[stream])
             LOGGER.info(f'under_target = {under_target} for {stream}')
 


### PR DESCRIPTION
# Description of change
The pagination test over [here](https://circleci.com/gh/singer-io/tap-hubspot/7869) and [here](https://circleci.com/gh/singer-io/tap-hubspot/7881) are failing with the status code 401. The expiry time of the access_token has been bought down from 6 hours to 30 minutes.
- To overcome the above failure, added refresh logic for access token after every 20 minutes (approx.)
- Add page limit size (250 the maximum API allows) for streams - `contact_lists` and `engagements`. Initially, it had a default of 100. This change will improve the integration test execution time in CircleCI.

Jira - [TDL-21142](https://jira.talendforge.org/browse/TDL-21142)

**NOTE** - This PR contains the changes only for integration tests.

 
# Risks
 - No risks to any customers.
 
# Rollback steps
 - revert this branch
