### PR TITLE
Add `activityType` and `teamId` to engagements schema

### DIFF
--- a/tap_hubspot/schemas/engagements.json
+++ b/tap_hubspot/schemas/engagements.json
@@ -33,6 +33,12 @@
         "timestamp": {
           "type": ["null", "string"],
           "format": "date-time"
+        },
+        "activityType": {
+          "type": ["null","string"]
+        },
+        "teamId": {
+          "type": ["null","string"]
         }
       }
     },


### PR DESCRIPTION
# Description of change
Adds `activityType` and `teamId` to the engagements stream.

# Manual QA steps
 - We've been using these fields internally for a over a year now and no problems so far 🤞 .
 
# Risks
 - No known risks
 
# Rollback steps
 - revert this branch
