### PR TITLE
Add meeting engagement fields

### DIFF
--- a/tap_hubspot/schemas/engagements.json
+++ b/tap_hubspot/schemas/engagements.json
@@ -172,6 +172,12 @@
         },
         "disposition": {
           "type": ["null", "string"]
+        },
+        "activityType": {
+          "type": ["null", "string"]
+        },
+        "meetingOutcome": {
+          "type": ["null", "string"]
         }
       }
     }


### PR DESCRIPTION
These fields are only present when engagement_type is meeting.

# Description of change
Meeting outcome and meeting activity types are currently missing from this tap.

https://developers.hubspot.com/docs/api/crm/meetings

# Manual QA steps
I'm a bit unsure of how to manually test this to see if it works - I'm using the stitch implementation of this. 

# Rollback steps
 - revert this branch
