### PR TITLE
Add new prefix to deals stream w/o for all fields test

### DIFF
--- a/tests/test_hubspot_all_fields.py
+++ b/tests/test_hubspot_all_fields.py
@@ -276,7 +276,10 @@ class TestHubspotAllFields(HubspotBaseTest):
                         #     to our test data. We have determined that the filtering of these fields is an expected behavior.
 
                         # deals workaround for 'property_hs_date_entered_<property>' fields
-                        bad_key_prefixes = {'property_hs_date_entered_', 'property_hs_date_exited_'}
+                        bad_key_prefixes = {'property_hs_date_entered_',
+                                            'property_hs_date_exited_',
+                                            'property_hs_time_in_example_'
+                                            }
                         bad_keys = set()
                         for key in expected_keys_adjusted:
                             for prefix in bad_key_prefixes:


### PR DESCRIPTION
# Description of change
A new field showed up for the deals stream that caused a tier 1 test regression failure.  Added it to the prefix list of bad keys to be removed from verification for the all fields test.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
