### PR TITLE
use sync start time to bookmark contacts stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.12.1
+  * Use sync start time for writing bookmarks [#226](https://github.com/singer-io/tap-hubspot/pull/226)
+
 ## 2.12.0
   * Include properties(default + custom) in tickets stream [#220](https://github.com/singer-io/tap-hubspot/pull/220)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-hubspot',
-      version='2.12.0',
+      version='2.12.1',
       description='Singer.io tap for extracting data from the HubSpot API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -517,6 +517,7 @@ def sync_contacts(STATE, ctx):
     # Dict to store replication key value for each contact record
     bookmark_values = {}
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
+        sync_start_time = utils.now()
         for row in gen_request(STATE, 'contacts', url, default_contact_params, 'contacts', 'has-more', ['vid-offset'], ['vidOffset']):
             modified_time = None
             if bookmark_key in row:
@@ -540,7 +541,7 @@ def sync_contacts(STATE, ctx):
 
         _sync_contact_vids(catalog, vids, schema, bumble_bee, bookmark_values, bookmark_key)
 
-    STATE = singer.write_bookmark(STATE, 'contacts', bookmark_key, utils.strftime(max_bk_value))
+    STATE = singer.write_bookmark(STATE, 'contacts', bookmark_key, utils.strftime(min(sync_start_time, max_bk_value)))
     singer.write_state(STATE)
     return STATE
 

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -517,6 +517,8 @@ def sync_contacts(STATE, ctx):
     # Dict to store replication key value for each contact record
     bookmark_values = {}
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
+        # To handle records updated between start of the table sync and the end,
+        # store the current sync start in the state and not move the bookmark past this value.
         sync_start_time = utils.now()
         for row in gen_request(STATE, 'contacts', url, default_contact_params, 'contacts', 'has-more', ['vid-offset'], ['vidOffset']):
             modified_time = None
@@ -541,7 +543,9 @@ def sync_contacts(STATE, ctx):
 
         _sync_contact_vids(catalog, vids, schema, bumble_bee, bookmark_values, bookmark_key)
 
-    STATE = singer.write_bookmark(STATE, 'contacts', bookmark_key, utils.strftime(min(sync_start_time, max_bk_value)))
+    # Don't bookmark past the start of this sync to account for updated records during the sync.
+    new_bookmark = min(max_bk_value, sync_start_time)
+    STATE = singer.write_bookmark(STATE, 'contacts', bookmark_key, utils.strftime(new_bookmark))
     singer.write_state(STATE)
     return STATE
 
@@ -706,6 +710,9 @@ def sync_deals(STATE, ctx):
     url = get_url('deals_all')
 
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
+        # To handle records updated between start of the table sync and the end,
+        # store the current sync start in the state and not move the bookmark past this value.
+        sync_start_time = utils.now()
         for row in gen_request(STATE, 'deals', url, params, 'deals', "hasMore", ["offset"], ["offset"], v3_fields=v3_fields):
             row_properties = row['properties']
             modified_time = None
@@ -724,7 +731,9 @@ def sync_deals(STATE, ctx):
                 record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
                 singer.write_record("deals", record, catalog.get('stream_alias'), time_extracted=utils.now())
 
-    STATE = singer.write_bookmark(STATE, 'deals', bookmark_key, utils.strftime(max_bk_value))
+    # Don't bookmark past the start of this sync to account for updated records during the sync.
+    new_bookmark = min(max_bk_value, sync_start_time)
+    STATE = singer.write_bookmark(STATE, 'deals', bookmark_key, utils.strftime(new_bookmark))
     singer.write_state(STATE)
     return STATE
 
@@ -776,6 +785,9 @@ def sync_tickets(STATE, ctx):
     url = get_url(stream_id)
 
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as transformer:
+        # To handle records updated between start of the table sync and the end,
+        # store the current sync start in the state and not move the bookmark past this value.
+        sync_start_time = utils.now()
         for row in gen_request_tickets(stream_id, url, params, 'results', "paging"):
             # parsing the string formatted date to datetime object
             modified_time = utils.strptime_to_utc(row[bookmark_key])
@@ -790,7 +802,9 @@ def sync_tickets(STATE, ctx):
             if modified_time and modified_time >= max_bk_value:
                 max_bk_value = modified_time
 
-    STATE = singer.write_bookmark(STATE, stream_id, bookmark_key, utils.strftime(max_bk_value))
+    # Don't bookmark past the start of this sync to account for updated records during the sync.
+    new_bookmark = min(max_bk_value, sync_start_time)
+    STATE = singer.write_bookmark(STATE, stream_id, bookmark_key, utils.strftime(new_bookmark))
     singer.write_state(STATE)
     return STATE
 
@@ -904,6 +918,9 @@ def sync_contact_lists(STATE, ctx):
     url = get_url("contact_lists")
     params = {'count': 250}
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
+        # To handle records updated between start of the table sync and the end,
+        # store the current sync start in the state and not move the bookmark past this value.
+        sync_start_time = utils.now()
         for row in gen_request(STATE, 'contact_lists', url, params, "lists", "has-more", ["offset"], ["offset"]):
             record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
 
@@ -912,7 +929,9 @@ def sync_contact_lists(STATE, ctx):
             if record[bookmark_key] >= max_bk_value:
                 max_bk_value = record[bookmark_key]
 
-    STATE = singer.write_bookmark(STATE, 'contact_lists', bookmark_key, max_bk_value)
+    # Don't bookmark past the start of this sync to account for updated records during the sync.
+    new_bookmark = min(utils.strptime_to_utc(max_bk_value), sync_start_time)
+    STATE = singer.write_bookmark(STATE, 'contact_lists', bookmark_key, utils.strftime(new_bookmark))
     singer.write_state(STATE)
 
     return STATE
@@ -933,6 +952,9 @@ def sync_forms(STATE, ctx):
     time_extracted = utils.now()
 
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
+        # To handle records updated between start of the table sync and the end,
+        # store the current sync start in the state and not move the bookmark past this value.
+        sync_start_time = utils.now()
         for row in data:
             record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
 
@@ -941,7 +963,9 @@ def sync_forms(STATE, ctx):
             if record[bookmark_key] >= max_bk_value:
                 max_bk_value = record[bookmark_key]
 
-    STATE = singer.write_bookmark(STATE, 'forms', bookmark_key, max_bk_value)
+    # Don't bookmark past the start of this sync to account for updated records during the sync.
+    new_bookmark = min(utils.strptime_to_utc(max_bk_value), sync_start_time)
+    STATE = singer.write_bookmark(STATE, 'forms', bookmark_key, utils.strftime(new_bookmark))
     singer.write_state(STATE)
 
     return STATE
@@ -964,6 +988,9 @@ def sync_workflows(STATE, ctx):
     time_extracted = utils.now()
 
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
+        # To handle records updated between start of the table sync and the end,
+        # store the current sync start in the state and not move the bookmark past this value.
+        sync_start_time = utils.now()
         for row in data['workflows']:
             record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
             if record[bookmark_key] >= start:
@@ -971,7 +998,9 @@ def sync_workflows(STATE, ctx):
             if record[bookmark_key] >= max_bk_value:
                 max_bk_value = record[bookmark_key]
 
-    STATE = singer.write_bookmark(STATE, 'workflows', bookmark_key, max_bk_value)
+    # Don't bookmark past the start of this sync to account for updated records during the sync.
+    new_bookmark = min(utils.strptime_to_utc(max_bk_value), sync_start_time)
+    STATE = singer.write_bookmark(STATE, 'workflows', bookmark_key, utils.strftime(new_bookmark))
     singer.write_state(STATE)
     return STATE
 
@@ -995,6 +1024,9 @@ def sync_owners(STATE, ctx):
     time_extracted = utils.now()
 
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
+        # To handle records updated between start of the table sync and the end,
+        # store the current sync start in the state and not move the bookmark past this value.
+        sync_start_time = utils.now()
         for row in data:
             record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
             if record[bookmark_key] >= max_bk_value:
@@ -1003,7 +1035,9 @@ def sync_owners(STATE, ctx):
             if record[bookmark_key] >= start:
                 singer.write_record("owners", record, catalog.get('stream_alias'), time_extracted=time_extracted)
 
-    STATE = singer.write_bookmark(STATE, 'owners', bookmark_key, max_bk_value)
+    # Don't bookmark past the start of this sync to account for updated records during the sync.
+    new_bookmark = min(utils.strptime_to_utc(max_bk_value), sync_start_time)
+    STATE = singer.write_bookmark(STATE, 'owners', bookmark_key, utils.strftime(new_bookmark))
     singer.write_state(STATE)
     return STATE
 

--- a/tap_hubspot/tests/test_deals.py
+++ b/tap_hubspot/tests/test_deals.py
@@ -2,13 +2,14 @@ from tap_hubspot import sync_deals
 from unittest.mock import patch, ANY
 
 
+@patch('builtins.min')
 @patch('tap_hubspot.Context.get_catalog_from_id', return_value={"metadata": ""})
 @patch('singer.metadata.to_map', return_value={})
 @patch('singer.utils.strptime_with_tz')
 @patch('singer.utils.strftime')
 @patch('tap_hubspot.load_schema')
 @patch('tap_hubspot.gen_request', return_value=[])
-def test_associations_are_not_validated(mocked_gen_request, mocked_catalog_from_id, mocked_metadata_map, mocked_utils_strptime, mocked_utils_strftime, mocked_load_schema):
+def test_associations_are_not_validated(mocked_gen_request, mocked_catalog_from_id, mocked_metadata_map, mocked_utils_strptime, mocked_utils_strftime, mocked_load_schema, mocked_min):
     # pylint: disable=unused-argument
     sync_deals({}, mocked_catalog_from_id)
 
@@ -17,13 +18,14 @@ def test_associations_are_not_validated(mocked_gen_request, mocked_catalog_from_
     mocked_gen_request.assert_called_once_with(ANY, ANY, ANY, expected_param, ANY, ANY, ANY, ANY, v3_fields=None)
 
 
+@patch('builtins.min')
 @patch('tap_hubspot.Context.get_catalog_from_id', return_value={"metadata": ""})
 @patch('singer.metadata.to_map', return_value={"associations": {"selected": True}})
 @patch('singer.utils.strptime_with_tz')
 @patch('singer.utils.strftime')
 @patch('tap_hubspot.load_schema')
 @patch('tap_hubspot.gen_request', return_value=[])
-def test_associations_are_validated(mocked_gen_request, mocked_catalog_from_id, mocked_metadata_map, mocked_utils_strptime, mocked_utils_strftime, mocked_load_schema):
+def test_associations_are_validated(mocked_gen_request, mocked_catalog_from_id, mocked_metadata_map, mocked_utils_strptime, mocked_utils_strftime, mocked_load_schema, mocked_min):
     # pylint: disable=unused-argument
     sync_deals({}, mocked_catalog_from_id)
 

--- a/tests/test_hubspot_interrupted_sync_offset.py
+++ b/tests/test_hubspot_interrupted_sync_offset.py
@@ -94,9 +94,14 @@ class TestHubspotInterruptedSyncOffsetContactLists(HubspotBaseTest):
         synced_records_2 = runner.get_records_from_target_output()
         state_2 = menagerie.get_state(conn_id)
 
-        # verify the uninterrupted sync and the simulated resuming sync end with the same bookmark values
-        with self.subTest(stream=stream):
-            self.assertEqual(state_1, state_2)
+        # Verify post-iterrupted sync bookmark should be greater than or equal to interrupted sync bookmark
+        # since newly created test records may get updated while stream is syncing
+        replication_keys = self.expected_replication_keys()
+        for stream in state_1.get('bookmarks'):
+            replication_key = list(replication_keys[stream])[0]
+            self.assertLessEqual(state_1["bookmarks"][stream].get(replication_key),
+                                 state_2["bookmarks"][stream].get(replication_key),
+                                 msg="First sync bookmark should not be greater than the second bookmark.")
 
 
 class TestHubspotInterruptedSyncOffsetContacts(TestHubspotInterruptedSyncOffsetContactLists):


### PR DESCRIPTION
# Description of change
For following streams, stream records were missed which were updated during stream was syncing.

- contacts
- contact_lists
- deals
- forms
- owners
- tickets
- workflows

Implemented a fix to bookmark minimum of stream sync start time and max. modifiedTime.

e.g.

Consider a scenario,

1. 1st sync started at 100 for vids 1-100 and completed in 5 seconds. (`max. modified_time=99`)
2. 2nd sync started at 105 for vids 101-200 and completed in 5 seconds. (`max. modified_time=103`)
3. While 2nd sync was in-progress, `vid_50` and `vid_250` got updated with 106 and 108 respectively.
4. Last sync started at 110 for vids 201-300 and completed in 5 seconds. (`max. modified_time=108`)

With existing implementation, after completion of sync, we set `bookmark_value=108`. This will miss the record `vid_50` updated at 106 in next sync. 

But if we set `bookmark_value=min(sync_start_time=100, max_modified_time=108)` i.e. 100, in next sync `vid_50` record will be synced, along with duplicate `vid_250` record.

# Manual QA steps
- Simulated scenario discussed above manually by pausing sync after `_sync_contact_vids()` for first 100 vids. Then updated one record from first batch of 100 vids (`vid=50`)and one record from next batch of vids (`vid=150`).
- Verified after `sync_contacts()` completed bookmark set is equal to `sync_start_time` which less than max modified time.
- Verified that in next sync, only those 2 `contacts` records were synced i.e. `vids=[50, 150]`.
- Verified bookmark set to max. `modified_time` between `vids=[50, 150]`
 
# Risks
 - In normal scenario, we should see least duplication of `contacts` stream records.
 - But if records are getting updated very frequently, then we may see noticeable amount of duplicate records.
 
# Rollback steps
 - revert this branch
