### PR TITLE
use engagements page size advanced option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.10.0
+  * Updated replication method as INCREMENTAL and replication key as property_hs_lastmodifieddate for deals and companies streams [#195](https://github.com/singer-io/tap-hubspot/pull/195)
+  * Fixed Pylint errors [#204](https://github.com/singer-io/tap-hubspot/pull/204)
+
 ## 2.9.6
   * Implement Request Timeout [#177](https://github.com/singer-io/tap-hubspot/pull/177)
   * Add version timestamp in contacts [#191](https://github.com/singer-io/tap-hubspot/pull/191

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.10.1
+  * Use engagements_page_size advanced option [#234](https://github.com/singer-io/tap-hubspot/pull/234)
+
 ## 2.10.0
   * Updated replication method as INCREMENTAL and replication key as property_hs_lastmodifieddate for deals and companies streams [#195](https://github.com/singer-io/tap-hubspot/pull/195)
   * Fixed Pylint errors [#204](https://github.com/singer-io/tap-hubspot/pull/204)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-hubspot',
-      version='2.10.0',
+      version='2.10.1',
       description='Singer.io tap for extracting data from the HubSpot API',
       author='Stitch',
       url='http://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-hubspot',
-      version='2.9.6',
+      version='2.10.0',
       description='Singer.io tap for extracting data from the HubSpot API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -936,7 +936,7 @@ def sync_engagements(STATE, ctx):
     singer.write_state(STATE)
 
     url = get_url("engagements_all")
-    params = {'limit': 250}
+    params = {'limit': int(CONFIG.get('engagements_page_size') or 250)}
     top_level_key = "results"
     engagements = gen_request(STATE, 'engagements', url, params, top_level_key, "hasMore", ["offset"], ["offset"])
 

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -936,7 +936,7 @@ def sync_engagements(STATE, ctx):
     singer.write_state(STATE)
 
     url = get_url("engagements_all")
-    params = {'limit': int(CONFIG.get('engagements_page_size') or 250)}
+    params = {'limit': int(CONFIG.get('engagements_page_size') or 190)}
     top_level_key = "results"
     engagements = gen_request(STATE, 'engagements', url, params, top_level_key, "hasMore", ["offset"], ["offset"])
 


### PR DESCRIPTION
# Description of change
Multiple clients received a 500 error from hubspot for the engagements table. Although the page limit max is 250 and works for most connections, hubspot advised to lower the page limit which fixed the 500 error. 
This pr adds lowers the page limit and an advanced option to make the page limit for the engagements table configurable. 

# Manual QA steps
 - tested with and without the advanced option set
 
# Risks
 - low
 
# Rollback steps
 - revert this branch
