### PR TITLE
Log the time difference of create time and post time

### DIFF
--- a/tests/client.py
+++ b/tests/client.py
@@ -1,6 +1,7 @@
 import datetime
 import random
 import uuid
+import sys
 
 import backoff
 import requests
@@ -16,6 +17,7 @@ class TestClient():
     V3_DEALS_PROPERTY_PREFIXES = {'hs_date_entered', 'hs_date_exited', 'hs_time_in'}
     BOOKMARK_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
     record_create_times = {}
+    time_difference=[]
 
     ##########################################################################
     ### CORE METHODS
@@ -759,7 +761,9 @@ class TestClient():
         elif stream == 'workflows':
             return self.create_workflows()
         elif stream == 'contacts':
-            return self.create_contacts()
+            records =  self.create_contacts()
+            self.record_create_times[stream]=self.time_difference
+            return records
         elif stream == 'deal_pipelines':
             return self.create_deal_pipelines()
         elif stream == 'email_events':
@@ -823,9 +827,9 @@ class TestClient():
             ]
         }
 
-        #Get the current time in seconds
-        date= datetime.datetime.utcnow() - datetime.datetime(1970, 1, 1)
-        seconds =(date.total_seconds())
+        # Get the current time in seconds
+        date = datetime.datetime.utcnow()
+        seconds = datetime.datetime.timestamp(date)
 
         # generate a contacts record
         response = self.post(url, data)
@@ -839,7 +843,7 @@ class TestClient():
         created_time = get_resp.get('properties').get('createdate').get('value')
         ts=int(created_time)/1000
         LOGGER.info("Created Time  %s", datetime.datetime.utcfromtimestamp(ts))
-        self.time_difference = ts-seconds
+        self.time_difference.append(ts-seconds)
 
         converted_versionTimestamp = self.BaseTest.datetime_from_timestamp(
             get_resp['versionTimestamp'] / 1000, self.BOOKMARK_DATE_FORMAT
@@ -1715,3 +1719,9 @@ class TestClient():
                 delete_count = int(max_record_count / 2)
                 self.cleanup(stream, records, delete_count)
                 LOGGER.info(f"TEST CLIENT | {delete_count} records deleted from {stream}")
+
+    def print_histogram_data(self):
+        for stream, recorded_times in self.record_create_times.items():
+            LOGGER.info("Time taken for stream {} is total: {}, avg: {}, minimum: {}, maximum: {}".
+                    format(stream, sum(recorded_times), sum(recorded_times)/len(recorded_times), min(recorded_times), max(recorded_times) ))
+

--- a/tests/client.py
+++ b/tests/client.py
@@ -15,6 +15,7 @@ class TestClient():
     START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
     V3_DEALS_PROPERTY_PREFIXES = {'hs_date_entered', 'hs_date_exited', 'hs_time_in'}
     BOOKMARK_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+    record_create_times = {}
 
     ##########################################################################
     ### CORE METHODS
@@ -822,6 +823,10 @@ class TestClient():
             ]
         }
 
+        #Get the current time in seconds
+        date= datetime.datetime.utcnow() - datetime.datetime(1970, 1, 1)
+        seconds =(date.total_seconds())
+
         # generate a contacts record
         response = self.post(url, data)
         records = [response]
@@ -830,9 +835,11 @@ class TestClient():
         params = {'includeVersion': True}
         get_resp = self.get(get_url, params=params)
 
+        #Get the created time and the difference to monitor the time difference - tdl-20939
         created_time = get_resp.get('properties').get('createdate').get('value')
         ts=int(created_time)/1000
         LOGGER.info("Created Time  %s", datetime.datetime.utcfromtimestamp(ts))
+        self.time_difference = ts-seconds
 
         converted_versionTimestamp = self.BaseTest.datetime_from_timestamp(
             get_resp['versionTimestamp'] / 1000, self.BOOKMARK_DATE_FORMAT

--- a/tests/client.py
+++ b/tests/client.py
@@ -17,7 +17,6 @@ class TestClient():
     V3_DEALS_PROPERTY_PREFIXES = {'hs_date_entered', 'hs_date_exited', 'hs_time_in'}
     BOOKMARK_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
     record_create_times = {}
-    time_difference=[]
 
     ##########################################################################
     ### CORE METHODS
@@ -761,8 +760,9 @@ class TestClient():
         elif stream == 'workflows':
             return self.create_workflows()
         elif stream == 'contacts':
+            if stream not in self.record_create_times.keys():
+                self.record_create_times[stream]=[]
             records =  self.create_contacts()
-            self.record_create_times[stream]=self.time_difference
             return records
         elif stream == 'deal_pipelines':
             return self.create_deal_pipelines()
@@ -843,7 +843,7 @@ class TestClient():
         created_time = get_resp.get('properties').get('createdate').get('value')
         ts=int(created_time)/1000
         LOGGER.info("Created Time  %s", datetime.datetime.utcfromtimestamp(ts))
-        self.time_difference.append(ts-seconds)
+        self.record_create_times["contacts"].append(ts-seconds)
 
         converted_versionTimestamp = self.BaseTest.datetime_from_timestamp(
             get_resp['versionTimestamp'] / 1000, self.BOOKMARK_DATE_FORMAT

--- a/tests/test_hubspot_bookmarks.py
+++ b/tests/test_hubspot_bookmarks.py
@@ -1,3 +1,4 @@
+import sys
 from datetime import datetime, timedelta
 from time import sleep
 
@@ -8,11 +9,11 @@ import tap_tester.runner      as runner
 
 from base import HubspotBaseTest
 from client import TestClient
+from tap_tester import LOGGER
 
 
 STREAMS_WITHOUT_UPDATES = {'email_events', 'contacts_by_company', 'workflows'}
 STREAMS_WITHOUT_CREATES = {'campaigns', 'owners'}
-
 
 class TestHubspotBookmarks(HubspotBaseTest):
     """Ensure tap replicates new and upated records based on the replication method of a given stream.
@@ -48,24 +49,46 @@ class TestHubspotBookmarks(HubspotBaseTest):
         self.test_client = TestClient(self.get_properties()['start_date'])
 
     def create_test_data(self, expected_streams):
+        """
+        Creating more records(5) instead of 3 to get the update time to build the histogram - tdl-20939
+        Excluding workflows as it results in assertion failures with expected_pk and sync_pk at line#261
+        """
 
         self.expected_records = {stream: []
                                  for stream in expected_streams}
-
+        self.times=0
         for stream in expected_streams - {'contacts_by_company'}:
-            if stream == 'email_events':
-                email_records = self.test_client.create(stream, times=3)
+            self.minimum=sys.maxsize
+            self.maximum=-sys.maxsize-1
+            if stream == 'contacts': 
+                self.times=10
+            else:
+                self.times =3
+
+            if stream in 'email_events':
+                email_records = self.test_client.create(stream, self.times)
                 self.expected_records['email_events'] += email_records
             else:
                 # create records, one will be updated between syncs
-                for _ in range(3):
+                time_diff =0
+                for _ in range(self.times):
                     record = self.test_client.create(stream)
                     self.expected_records[stream] += record
+                    if stream in 'contacts':
+                        if self.test_client.time_difference < self.minimum:
+                            self.minimum = self.test_client.time_difference
+                        if self.test_client.time_difference > self.maximum:
+                            self.maximum = self.test_client.time_difference
+                        time_diff += self.test_client.time_difference 
+
+                if stream in 'contacts':
+                    self.avg = time_diff/5
+                    self.test_client.record_create_times[stream] = time_diff
 
         if 'contacts_by_company' in expected_streams:  # do last
             company_ids = [record['companyId'] for record in self.expected_records['companies']]
             contact_records = self.expected_records['contacts']
-            for i in range(3):
+            for i in range(self.times):
                 record = self.test_client.create_contacts_by_company(
                     company_ids=company_ids, contact_records=contact_records
                 )
@@ -246,3 +269,7 @@ class TestHubspotBookmarks(HubspotBaseTest):
                               'email_events'}: # BUG | https://jira.talendforge.org/browse/TDL-15706
                     continue  # skipping failures
                 self.assertTrue(any([expected_pk in sync_2_pks for expected_pk in expected_sync_1_pks]))
+
+        #Logging for monitoring the time difference for all streams
+        LOGGER.info("Time_difference between Created time and POST message: For 10 records in contacts")
+        LOGGER.info("total: %s, min: %s, max: %s, avg: %s", self.test_client.record_create_times, self.minimum, self.maximum, self.avg)

--- a/tests/test_hubspot_bookmarks.py
+++ b/tests/test_hubspot_bookmarks.py
@@ -55,7 +55,6 @@ class TestHubspotBookmarks(HubspotBaseTest):
         self.expected_records = {stream: []
                                  for stream in expected_streams}
         for stream in expected_streams - {'contacts_by_company'}:
-            self.time_difference =[]
             if stream == 'contacts': 
                 self.times=10
             else:


### PR DESCRIPTION
# Description of change
https://jira.talendforge.org/browse/TDL-20939
The change is to add more logging to decide on further steps to a discrepancy in bookmark test that occurs occassionally in stream contacts.
Log the time difference between the post message and the create time when a record is created to decide if we want to have a lookback window.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
