### PR TITLE
Tdl 24590 fix contacts to company

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -77,6 +77,7 @@ ENDPOINTS = {
     "companies_recent":     "/companies/v2/companies/recent/modified",
     "companies_detail":     "/companies/v2/companies/{company_id}",
     "contacts_by_company":  "/companies/v2/companies/{company_id}/vids",
+    "contacts_by_company_v3_batch_read": "/crm/v3/associations/company/contact/batch/read",
 
     "deals_properties":     "/properties/v1/deals/properties",
     "deals_all":            "/deals/v1/deal/paged",
@@ -560,31 +561,38 @@ def use_recent_companies_endpoint(response):
 default_contacts_by_company_params = {'count' : 100}
 
 # NB> to do: support stream aliasing and field selection
-def _sync_contacts_by_company(STATE, ctx, company_id):
+def _sync_contacts_by_company_batch_read(STATE, ctx, company_ids):
     schema = load_schema(CONTACTS_BY_COMPANY)
     catalog = ctx.get_catalog_from_id(singer.get_currently_syncing(STATE))
     mdata = metadata.to_map(catalog.get('metadata'))
-    url = get_url("contacts_by_company", company_id=company_id)
-    path = 'vids'
+    url = get_url("contacts_by_company_v3_batch_read")
+
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
         with metrics.record_counter(CONTACTS_BY_COMPANY) as counter:
-            data = request(url, default_contacts_by_company_params).json()
+            data = {'inputs': []}
+            [data['inputs'].append({'id': company_id}) for company_id in company_ids]
+            contacts_to_company_rows = post_search_endpoint(url, data).json()
 
-            if data.get(path) is None:
-                raise RuntimeError("Unexpected API response: {} not in {}".format(path, data.keys()))
-
-            for row in data[path]:
-                counter.increment()
-                record = {'company-id' : company_id,
-                          'contact-id' : row}
-                record = bumble_bee.transform(lift_properties_and_versions(record), schema, mdata)
-                singer.write_record("contacts_by_company", record, time_extracted=utils.now())
-
-    return STATE
+            for row in contacts_to_company_rows['results']:
+                for contact in row['to']:
+                    counter.increment()
+                    record = {'company-id' : row['from']['id'],
+                              'contact-id' : contact['id']}
+                    record = bumble_bee.transform(lift_properties_and_versions(record), schema, mdata)
+                    singer.write_record("contacts_by_company", record, time_extracted=utils.now())
 
 default_company_params = {
     'limit': 250, 'properties': ["createdate", "hs_lastmodifieddate"]
 }
+
+def sync_company_details(companies, catalog, mdata, schema, start):
+    with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
+        for company in companies:
+            if not company['modified_time'] or company['modified_time'] >= start:
+                record = request(get_url("companies_detail",
+                                company_id=company['id'])).json()
+                record = bumble_bee.transform(lift_properties_and_versions(record), schema, mdata)
+                singer.write_record("companies", record, catalog.get('stream_alias'), time_extracted=utils.now())
 
 def sync_companies(STATE, ctx):
     catalog = ctx.get_catalog_from_id(singer.get_currently_syncing(STATE))
@@ -614,6 +622,9 @@ def sync_companies(STATE, ctx):
         contacts_by_company_schema = load_schema(CONTACTS_BY_COMPANY)
         singer.write_schema("contacts_by_company", contacts_by_company_schema, ["company-id", "contact-id"])
 
+    # We will process the companies and contacts_by_cmpany records in batches of default limit size
+    # This list will store the company records until bucket size is reached and records finished
+    companies = []
     with bumble_bee:
         for row in gen_request(STATE, 'companies', url, default_company_params, 'companies', 'has-more', ['offset'], ['offset']):
             row_properties = row['properties']
@@ -630,12 +641,23 @@ def sync_companies(STATE, ctx):
             if modified_time and modified_time >= max_bk_value:
                 max_bk_value = modified_time
 
-            if not modified_time or modified_time >= start:
-                record = request(get_url("companies_detail", company_id=row['companyId'])).json()
-                record = bumble_bee.transform(lift_properties_and_versions(record), schema, mdata)
-                singer.write_record("companies", record, catalog.get('stream_alias'), time_extracted=utils.now())
+            companies.append({'id': row['companyId'], 'modified_time': modified_time})
+
+            # Process the company and contacts_by_ompany records once list size reaches default limit (=250)
+            if len(companies) >= default_company_params['limit']:
+                sync_company_details(companies, catalog, mdata, schema, start)
+
                 if CONTACTS_BY_COMPANY in ctx.selected_stream_ids:
-                    STATE = _sync_contacts_by_company(STATE, ctx, record['companyId'])
+                    _sync_contacts_by_company_batch_read(STATE, ctx, [company['id'] for company in companies])
+
+                companies = []
+
+    # Stream may have less the default limit (=250) records, also last batch may have less records than the limit set
+    # Following code will handle those remaining company records
+    sync_company_details(companies, catalog, mdata, schema, start)
+
+    if CONTACTS_BY_COMPANY in ctx.selected_stream_ids:
+        _sync_contacts_by_company_batch_read(STATE, ctx, [company['id'] for company in companies])
 
     # Don't bookmark past the start of this sync to account for updated records during the sync.
     new_bookmark = min(max_bk_value, current_sync_start)

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -647,8 +647,8 @@ def sync_companies(STATE, ctx):
                 company_ids.append(row['companyId'])
                 # Process the company and contacts_by_ompany records once list size reaches default limit (=250)
                 if len(company_ids) >= default_company_params['limit']:
-                    _sync_contacts_by_company_batch_read(STATE, ctx, company_ids)
-                    company_ids = []
+                        _sync_contacts_by_company_batch_read(STATE, ctx, company_ids)
+                        company_ids = []
 
     # Stream may have less the default limit (=250) records, also last batch may have less records than the limit set
     # Following code will handle those remaining company records

--- a/tests/test_hubspot_all_fields.py
+++ b/tests/test_hubspot_all_fields.py
@@ -37,7 +37,7 @@ KNOWN_EXTRA_FIELDS = {
         # BUG_TDL-14993 | https://jira.talendforge.org/browse/TDL-14993
         #                 Has an value of object with key 'value' and value 'Null'
         'property_hs_date_entered_1258834',
-        'property_hs_time_in_example_stage1660743867503491_315775040'
+        'property_hs_time_in_example_stage1660743867503491_315775040',
     },
 }
 
@@ -155,6 +155,7 @@ KNOWN_MISSING_FIELDS = {
         'property_hs_analytics_latest_source_data_2_company',
         'property_hs_analytics_latest_source_data_2',
         'property_hs_analytics_latest_source_data_2_contact',
+        'property_hs_deal_score',
     },
     'subscription_changes':{
         'normalizedEmailId'


### PR DESCRIPTION
# Description of change
Currently we make a request to retrieve `contacts_by_company` per `company_id`. But this results in performance issue [TDL-24590](https://jira.talendforge.org/browse/TDL-24590), if we have large number of company ids. To overcome this issue, we will make one request for 250 company ids in a batch to retrieve `contacts_by_company` which will reduce number of `contacts_by_company` requests almost by 250 times.

# Manual QA steps
 - Verified number of records match with original implementation
 - Verified different interrupted sync scenarios
     - No offset set for `contacts_by_company` to simulate existing connection scenario
     - `contacts_by_company` offset is lesser than `companies` offset
     - `contacts_by_company` offset is greater than `companies` offset (observed this scenario in internal testing)
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
