### PR TITLE
Refactor the code and Correct Replication Methods

### DIFF
--- a/tap_hubspot/tests/unittests/test_tickets.py
+++ b/tap_hubspot/tests/unittests/test_tickets.py
@@ -122,7 +122,7 @@ class TestTickets(unittest.TestCase):
 
     @patch('tap_hubspot.request', return_value=MockResponse(mock_response_data))
     @patch('tap_hubspot.get_start', return_value='2023-01-01T00:00:00Z')
-    @patch('tap_hubspot.gen_request_tickets')
+    @patch('tap_hubspot.get_v3_records')
     def test_ticket_params_are_validated(self, mocked_gen_request, mocked_get_start,
                                          mock_request_response):
         """


### PR DESCRIPTION
# Description of change

- Created a new function to encapsulate the common logic shared by the ticket and owners streams.
- Updated the ticket and owners streams to utilize the new function.
- Corrected the replication methods for streams - `forms`, `workflows`, `contact_lists` and `engagements`.

# Manual QA steps
 - Verified that the refactored code maintains the same functionality as before.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
