### PR TITLE
Tdl 26414 rename custom objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.0
+  * Renames custom object that shares name with standard objects [#263](https://github.com/singer-io/tap-hubspot/pull/263)
+
 ## 3.0.0
   * Upgrade Owners API endpoint [#256](https://github.com/singer-io/tap-hubspot/pull/256)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-hubspot',
-      version='3.0.0',
+      version='3.1.0',
       description='Singer.io tap for extracting data from the HubSpot API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -1155,7 +1155,7 @@ def sync_custom_objects(stream_id, primary_key, bookmark_key, catalog, STATE, pa
     """
     mdata = metadata.to_map(catalog.get('metadata'))
     if is_custom_object:
-        url = get_url("custom_objects", object_name=catalog["stream_alias"])
+        url = get_url("custom_objects", object_name=catalog["table_name"])
     else:
         url = get_url(stream_id)
     max_bk_value = bookmark_value = utils.strptime_with_tz(
@@ -1180,7 +1180,7 @@ def sync_custom_objects(stream_id, primary_key, bookmark_key, catalog, STATE, pa
                 # transforms the data and filters out the selected fields from the catalog
                 record = transformer.transform(lift_properties_and_versions(row), schema, mdata)
                 singer.write_record(stream_id, record, catalog.get(
-                    'stream_alias'), time_extracted=utils.now())
+                    'stream'), time_extracted=utils.now())
             if modified_time and modified_time >= max_bk_value:
                 max_bk_value = modified_time
 
@@ -1426,7 +1426,7 @@ def discover_schemas():
         LOGGER.info('Loading schema for Custom Object - %s', custom_stream["stream"].tap_stream_id)
         result['streams'].append({'stream': custom_stream["stream"].tap_stream_id,
                                   'tap_stream_id': custom_stream["stream"].tap_stream_id,
-                                  "stream_alias": custom_stream["custom_object_name"],
+                                  "table_name": custom_stream["custom_object_name"],
                                   'schema': custom_stream["schema"],
                                   'metadata': get_metadata(custom_stream["stream"], custom_stream["schema"])})
 

--- a/tap_hubspot/tests/unittests/test_custom_objects.py
+++ b/tap_hubspot/tests/unittests/test_custom_objects.py
@@ -7,6 +7,7 @@ MOCK_CATALOG = {
         {
             "stream": "cars",
             "tap_stream_id": "cars",
+            "table_name": "cars",
             "schema": {
                 "type": "object",
                 "properties": {
@@ -81,7 +82,8 @@ class TestGenerateCustomStreams(unittest.TestCase):
             "properties": {"property_fake_object": "fake_value"},
         }
         expected_value = [
-            {'stream': Stream(tap_stream_id='fake_object', sync=mock_sync_custom_records, key_properties=['id'], replication_key='updatedAt', replication_method='INCREMENTAL'), 
+            {'custom_object_name':'fake_object',
+             'stream': Stream(tap_stream_id='fake_object', sync=mock_sync_custom_records, key_properties=['id'], replication_key='updatedAt', replication_method='INCREMENTAL'), 
              'schema': {'type': 'object', 'properties': {'property_fake_object': 'fake_value'}}}]
 
         # Set up mock return values

--- a/tests/base.py
+++ b/tests/base.py
@@ -170,6 +170,20 @@ class HubspotBaseTest(BaseCase):
                 self.REPLICATION_KEYS: {"updatedAt"},
                 self.EXPECTED_PAGE_SIZE: 100,
                 self.OBEYS_START_DATE: True
+            },
+            "custom_object_campaigns": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"updatedAt"},
+                self.EXPECTED_PAGE_SIZE: 100,
+                self.OBEYS_START_DATE: True
+            },
+            "custom_object_contacts": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"updatedAt"},
+                self.EXPECTED_PAGE_SIZE: 100,
+                self.OBEYS_START_DATE: True
             }
         }
 

--- a/tests/base_hubspot.py
+++ b/tests/base_hubspot.py
@@ -157,6 +157,22 @@ class HubspotBaseCase(BaseCase):
                 BaseCase.API_LIMIT: 100,
                 BaseCase.EXPECTED_PAGE_SIZE: 100,
                 BaseCase.OBEYS_START_DATE: True
+            },
+            "custom_object_campaigns": {
+                BaseCase.PRIMARY_KEYS: {"id"},
+                BaseCase.REPLICATION_METHOD: BaseCase.INCREMENTAL,
+                BaseCase.REPLICATION_KEYS: {"updatedAt"},
+                BaseCase.API_LIMIT: 100,
+                BaseCase.EXPECTED_PAGE_SIZE: 100,
+                BaseCase.OBEYS_START_DATE: True
+            },
+            "custom_object_contacts": {
+                BaseCase.PRIMARY_KEYS: {"id"},
+                BaseCase.REPLICATION_METHOD: BaseCase.INCREMENTAL,
+                BaseCase.REPLICATION_KEYS: {"updatedAt"},
+                BaseCase.API_LIMIT: 100,
+                BaseCase.EXPECTED_PAGE_SIZE: 100,
+                BaseCase.OBEYS_START_DATE: True
             }
 
         }

--- a/tests/client.py
+++ b/tests/client.py
@@ -1,7 +1,7 @@
 import datetime
 import random
 import uuid
-import sys
+import string
 
 import backoff
 import requests
@@ -839,7 +839,7 @@ class TestClient():
             return self.create_subscription_changes(subscriptions, times)
         elif stream == 'tickets':
             return self.create_tickets()
-        elif stream in ["cars", "co_firsts"]:
+        elif stream in ["cars", "co_firsts", "custom_object_contacts", "custom_object_campaigns"]:
             return self.create_custom_object_record(stream)
         else:
             raise NotImplementedError(f"There is no create_{stream} method in this dipatch!")
@@ -1148,6 +1148,11 @@ class TestClient():
 
         return records
 
+    def generate_random_string(self, length):
+        characters = string.ascii_letters + string.digits
+        random_string = ''.join(random.choice(characters) for _ in range(length))
+        return random_string
+
     def create_custom_object_record(self, stream):
         url = f"{BASE_URL}/crm/v3/objects/p_{stream}"
 
@@ -1170,6 +1175,23 @@ class TestClient():
             data = {
                 "properties": {
                     "id": random.randint(1, 100000),
+                    "name": "test name",
+                    "country": random.choice(["USA", "India", "France", "UK"])
+                }
+            }
+        elif stream == "custom_object_campaigns":
+            url = f"{BASE_URL}/crm/v3/objects/p_campaigns"
+            data = {
+                "properties": {
+                    "co_campaign_id": random.randint(1, 100000),
+                    "name": "test name",
+                    "country": random.choice(["USA", "India", "France", "UK"])
+                }
+            }
+        elif stream == "custom_object_contacts":
+            data = {
+                "properties": {
+                    "co_contact_id": random.randint(1, 100000),
                     "name": "test name",
                     "country": random.choice(["USA", "India", "France", "UK"])
                 }

--- a/tests/client.py
+++ b/tests/client.py
@@ -1185,7 +1185,7 @@ class TestClient():
                     "country": random.choice(["USA", "India", "France", "UK"])
                 }
             }
-        elif stream == "custom_object_campaigns":
+        elif stream == "campaigns":
             url = f"{BASE_URL}/crm/v3/objects/p_campaigns"
             data = {
                 "properties": {

--- a/tests/test_hubspot_all_fields.py
+++ b/tests/test_hubspot_all_fields.py
@@ -98,7 +98,8 @@ KNOWN_MISSING_FIELDS = {
         'activeSalesforceId',
 
         # Field is returned by API but not listed in official Hubspot documentation
-        'userIdIncludingInactive'
+        'userIdIncludingInactive',
+        'type'
     },
     'forms': {  # BUG https://jira.talendforge.org/browse/TDL-15001
         'alwaysCreateNewCompany',
@@ -167,7 +168,8 @@ KNOWN_MISSING_FIELDS = {
         'property_hs_v2_date_exited_appointmentscheduled',
         'property_hs_v2_latest_time_in_appointmentscheduled',
         'property_hs_v2_cumulative_time_in_appointmentscheduled',
-        'property_hs_v2_date_entered_qualifiedtobuy'
+        'property_hs_v2_date_entered_qualifiedtobuy',
+        'property_deal_currency_code'
     },
     'subscription_changes':{
         'normalizedEmailId'


### PR DESCRIPTION
# Description of change
This PR addresses an issue where `custom objects` in HubSpot can have the same names as `standard objects` (e.g., contacts, campaigns), leading to extraction failures [TDL-26380](https://jira.talendforge.org/browse/TDL-26380). 

The fix involves renaming custom objects that share names with standard objects to a distinct `custom_object_<standard_object_name>`. This ensures that custom objects are clearly differentiated from standard objects, preventing conflicts and extraction issues.

# Manual QA steps

- [x] Verify that streams of conflicting custom objects have been renamed correctly.
- [x] Verify that custom objects initially named custom_object_<standard_object_name> are extracted as expected.
- [x] Verify that the standard and renamed custom object streams are extracted properly.

 
# Risks
 - 
 
# Rollback steps
 - revert this branch

