### PR TITLE
TDL-26642: Support new properties foe deals stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.1
+  * Replace legacy properties for Contacts and Deals [#265](https://github.com/singer-io/tap-hubspot/pull/265)
+
 ## 3.1.0
   * Renames custom object that shares name with standard objects [#263](https://github.com/singer-io/tap-hubspot/pull/263)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-hubspot',
-      version='3.1.0',
+      version='3.1.1',
       description='Singer.io tap for extracting data from the HubSpot API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -424,8 +424,8 @@ def merge_responses(v1_data, v3_data):
 def process_v3_deals_records(v3_data):
     """
     This function:
-    1. filters out fields that don't contain 'hs_date_entered_*' and
-       'hs_date_exited_*'
+    1. filters out fields that don't contain 'hs_v2_date_entered_*' and
+       'hs_v2_date_exited_*'
     2. changes a key value pair in `properties` to a key paired to an
        object with a key 'value' and the original value
     """
@@ -741,7 +741,7 @@ def sync_deals(STATE, ctx):
         params['includeAllProperties'] = True
         params['allPropertiesFetchMode'] = 'latest_version'
 
-        # Grab selected `hs_date_entered/exited` fields to call the v3 endpoint with
+        # Grab selected `hs_v2_date_entered/exited` fields to call the v3 endpoint with
         v3_fields = [breadcrumb[1].replace('property_', '')
                      for breadcrumb, mdata_map in mdata.items()
                      if breadcrumb

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -48,7 +48,7 @@ CONTACTS_BY_COMPANY = "contacts_by_company"
 
 DEFAULT_CHUNK_SIZE = 1000 * 60 * 60 * 24
 
-V3_PREFIXES = {'hs_date_entered', 'hs_date_exited', 'hs_time_in'}
+V3_PREFIXES = {'hs_v2_date_entered', 'hs_v2_date_exited', 'hs_v2_latest_time_in'}
 
 CONFIG = {
     "access_token": None,
@@ -442,7 +442,7 @@ def get_v3_deals(v3_fields, v1_data):
 
     # Sending the first v3_field is enough to get them all
     v3_body = {'inputs': v1_ids,
-               'properties': [v3_fields[0]],}
+               'properties': v3_fields}
     v3_url = get_url('deals_v3_batch_read')
     v3_resp = post_search_endpoint(v3_url, v3_body)
     return v3_resp.json()['results']

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -440,7 +440,6 @@ def process_v3_deals_records(v3_data):
 def get_v3_deals(v3_fields, v1_data):
     v1_ids = [{'id': str(record['dealId'])} for record in v1_data]
 
-    # Sending the first v3_field is enough to get them all
     v3_body = {'inputs': v1_ids,
                'properties': v3_fields}
     v3_url = get_url('deals_v3_batch_read')

--- a/tests/client.py
+++ b/tests/client.py
@@ -16,7 +16,7 @@ BASE_URL = "https://api.hubapi.com"
 
 class TestClient():
     START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
-    V3_DEALS_PROPERTY_PREFIXES = {'hs_date_entered', 'hs_date_exited', 'hs_time_in'}
+    V3_DEALS_PROPERTY_PREFIXES = {'hs_v2_date_entered', 'hs_v2_date_exited', 'hs_v2_latest_time_in'}
     BOOKMARK_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
     record_create_times = {}
 
@@ -498,7 +498,7 @@ class TestClient():
 
         # hit the v3 endpoint to get the special hs_<whatever> fields from v3 'properties'
         v3_url = f"{BASE_URL}/crm/v3/objects/deals/batch/read"
-        v3_property = ['hs_date_entered_appointmentscheduled']
+        v3_property = ['hs_v2_date_entered_appointmentscheduled']
         v3_records = []
         for batch in batches:
             data = {'inputs': batch,
@@ -1205,6 +1205,10 @@ class TestClient():
 
         # generate a record
         response = self.post(url, data)
+        if "status" in response and response["status"] == "error":
+            LOGGER.debug("Error creating record: %s", response.get('message', ''))
+            return self.create_custom_object_record(stream)
+
         return [response]
 
     def create_deal_pipelines(self):

--- a/tests/test_hubspot_all_fields.py
+++ b/tests/test_hubspot_all_fields.py
@@ -164,6 +164,9 @@ KNOWN_MISSING_FIELDS = {
         'property_hs_analytics_latest_source_data_2_contact',
         'property_hs_deal_score',
         'property_hs_is_active_shared_deal',
+        'property_hs_v2_date_entered_appointmentscheduled',
+        'property_hs_v2_date_exited_appointmentscheduled',
+        'property_hs_v2_latest_time_in_appointmentscheduled',
         'property_hs_v2_cumulative_time_in_appointmentscheduled',
         'property_hs_v2_date_entered_qualifiedtobuy',
         'property_deal_currency_code'

--- a/tests/test_hubspot_all_fields.py
+++ b/tests/test_hubspot_all_fields.py
@@ -182,9 +182,6 @@ class TestHubspotAllFields(HubspotBaseTest):
 
     def streams_under_test(self):
         """expected streams minus the streams not under test"""
-        return {
-            'deals'
-        }
         return self.expected_streams().difference({
             'owners',
             'subscription_changes', # BUG_TDL-14938 https://jira.talendforge.org/browse/TDL-14938

--- a/tests/test_hubspot_all_fields.py
+++ b/tests/test_hubspot_all_fields.py
@@ -164,9 +164,6 @@ KNOWN_MISSING_FIELDS = {
         'property_hs_analytics_latest_source_data_2_contact',
         'property_hs_deal_score',
         'property_hs_is_active_shared_deal',
-        'property_hs_v2_date_entered_appointmentscheduled',
-        'property_hs_v2_date_exited_appointmentscheduled',
-        'property_hs_v2_latest_time_in_appointmentscheduled',
         'property_hs_v2_cumulative_time_in_appointmentscheduled',
         'property_hs_v2_date_entered_qualifiedtobuy',
         'property_deal_currency_code'
@@ -185,6 +182,9 @@ class TestHubspotAllFields(HubspotBaseTest):
 
     def streams_under_test(self):
         """expected streams minus the streams not under test"""
+        return {
+            'deals'
+        }
         return self.expected_streams().difference({
             'owners',
             'subscription_changes', # BUG_TDL-14938 https://jira.talendforge.org/browse/TDL-14938

--- a/tests/test_hubspot_interrupted_sync_offset.py
+++ b/tests/test_hubspot_interrupted_sync_offset.py
@@ -125,7 +125,9 @@ class TestHubspotInterruptedSyncOffsetContacts(TestHubspotInterruptedSyncOffsetC
 
     def get_properties(self):
         return {
-            'start_date' : '2021-10-01T00:00:00Z'
+            'start_date' : datetime.strftime(
+                datetime.today()-timedelta(days=3), self.START_DATE_FORMAT
+            ),
         }
 
 
@@ -143,8 +145,10 @@ class TestHubspotInterruptedSyncOffsetDeals(TestHubspotInterruptedSyncOffsetCont
         return "tt_hubspot_interrupt_deals"
 
     def get_properties(self):
-        return {
-            'start_date' : '2021-10-10T00:00:00Z'
+        return  {
+            'start_date' : datetime.strftime(
+                datetime.today()-timedelta(days=3), self.START_DATE_FORMAT
+            ),
         }
 
     def stream_to_interrupt(self):
@@ -164,7 +168,9 @@ class TestHubspotInterruptedSyncOffsetCompanies(TestHubspotInterruptedSyncOffset
 
     def get_properties(self):
         return {
-            'start_date' : '2023-12-31T00:00:00Z'
+            'start_date' : datetime.strftime(
+                datetime.today()-timedelta(days=3), self.START_DATE_FORMAT
+            ),
         }
 
     def stream_to_interrupt(self):

--- a/tests/unittests/test_deals.py
+++ b/tests/unittests/test_deals.py
@@ -38,7 +38,7 @@ class TestDeals(unittest.TestCase):
         params = {'count': 250,
                   'includeAssociations': False,
                   'properties' : []}
-        v3_fields = ['hs_date_entered_appointmentscheduled']
+        v3_fields = ['hs_v2_date_entered_appointmentscheduled']
 
         records = list(
             gen_request(state, 'deals', url, params, 'deals', "hasMore", ["offset"], ["offset"], v3_fields=v3_fields)
@@ -46,8 +46,8 @@ class TestDeals(unittest.TestCase):
 
         for record in records:
             # The test account has a deal stage called "appointment scheduled"
-            value = record.get('properties',{}).get('hs_date_entered_appointmentscheduled')
-            error_msg = ('Could not find "hs_date_entered_appointment_scheduled"'
+            value = record.get('properties',{}).get('hs_v2_date_entered_appointmentscheduled')
+            error_msg = ('Could not find "hs_v2_date_entered_appointment_scheduled"'
                          'in {}').format(record)
             self.assertIsNotNone(value, msg=error_msg)
 
@@ -56,13 +56,13 @@ class TestDeals(unittest.TestCase):
         data = [
             {'properties': {'field1': 'value1',
                             'field2': 'value2',
-                            'hs_date_entered_field3': 'value3',
-                            'hs_date_exited_field4': 'value4',}},
+                            'hs_v2_date_entered_field3': 'value3',
+                            'hs_v2_date_exited_field4': 'value4',}},
         ]
 
         expected = [
-            {'properties': {'hs_date_entered_field3': {'value': 'value3'},
-                            'hs_date_exited_field4':  {'value': 'value4'},}},
+            {'properties': {'hs_v2_date_entered_field3': {'value': 'value3'},
+                            'hs_v2_date_exited_field4':  {'value': 'value4'},}},
         ]
 
         actual = process_v3_deals_records(data)


### PR DESCRIPTION
# Description of change
In the tap-HubSpot integration, we currently fetch the properties schema dynamically for certain streams, including contacts and deals. Starting from [November 20](https://developers.hubspot.com/changelog/upcoming-sunset-of-pipeline-legacy-stage-calculated-properties-for-contacts-and-deals?utm_campaign=App%20Partner%20Comms%202024&utm_medium=email&utm_content=326637210&utm_source=hs_email), certain API properties will no longer be returned.

- hs_lifecyclestage_{stage id}
- hs_date_entered_{stage id}
- hs_date_exited_{stage id}
- hs_time_in_{stage id}

Instead, we will need to rely on the new set of properties.
- hs_v2_date_entered_{stage_id}
- hs_v2_date_exited_{stage_id}
- hs_v2_latest_time_in_{stage_id}
- Hs_v2_cumulative_time_in_{stage_id}

Since these are dynamic properties, we have both sets of properties present in the schema at the moment. We just need to update the code for the deals stream to ensure that only the newly required properties are requested going forward.

# Manual QA steps
 - Run the discover mode and verify the generated catalog.
 - Run the sync mode and verify the records.
 - Run the sync mode and verify the state.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
