### PR TITLE
SAC-30347: fix interrupted sync test

### DIFF
--- a/tests/test_hubspot_interrupted_sync.py
+++ b/tests/test_hubspot_interrupted_sync.py
@@ -18,9 +18,7 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
 
     def streams_to_test(self):
         """expected streams minus the streams not under test"""
-        # BUG https://qlik-dev.atlassian.net/browse/SAC-30347,
-        # add tickets and engagements into streams_to_test after resolving
-        return {'companies', 'contacts'}
+        return {'companies', 'contacts', 'tickets', 'engagements'}
 
     def simulated_interruption(self, reference_state):
 
@@ -33,18 +31,17 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
         new_state['bookmarks']['companies']['property_hs_lastmodifieddate'] = None
         new_state['bookmarks']['companies']['current_sync_start'] = companies_bookmark
 
-        # Uncomment after SAC-30347 is resloved
-        # engagements_bookmark = self.timedelta_formatted(
-        #     reference_state['bookmarks']['engagements']['lastUpdated'],
-        #     days=-1, str_format=self.BASIC_DATE_FORMAT
-        # )
-        # new_state['bookmarks']['engagements']['lastUpdated'] = None
-        # new_state['bookmarks']['engagements']['current_sync_start'] = engagements_bookmark
+        engagements_bookmark = self.timedelta_formatted(
+            reference_state['bookmarks']['engagements']['lastUpdated'],
+            days=-1, str_format=self.BASIC_DATE_FORMAT
+        )
+        new_state['bookmarks']['engagements']['lastUpdated'] = None
+        new_state['bookmarks']['engagements']['current_sync_start'] = engagements_bookmark
 
-        # tickets_bookmark = self.timedelta_formatted(
-        #     reference_state['bookmarks']['tickets']['updatedAt'],
-        #     days=-1, str_format=self.BASIC_DATE_FORMAT)
-        # new_state['bookmarks']['tickets']['updatedAt'] = tickets_bookmark
+        tickets_bookmark = self.timedelta_formatted(
+            reference_state['bookmarks']['tickets']['updatedAt'],
+            days=-1, str_format=self.BASIC_DATE_FORMAT)
+        new_state['bookmarks']['tickets']['updatedAt'] = tickets_bookmark
 
         contacts_bookmark = self.timedelta_formatted(
             reference_state['bookmarks']['contacts']['updatedAt'],
@@ -55,12 +52,12 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
 
     def get_properties(self):
         #        'start_date' : '2021-08-19T00:00:00Z'
-        # return {'start_date' : '2017-11-22T00:00:00Z'}
-        return {
-            'start_date' : datetime.strftime(
-                datetime.today()-timedelta(days=5), self.START_DATE_FORMAT
-            ),
-        }
+        return {'start_date' : '2017-11-22T00:00:00Z'}
+        # return {
+        #     'start_date' : datetime.strftime(
+        #         datetime.today()-timedelta(days=5), self.START_DATE_FORMAT
+        #     ),
+        # }
 
     def setUp(self):
         self.maxDiff = None  # see all output in failure

--- a/tests/test_hubspot_interrupted_sync.py
+++ b/tests/test_hubspot_interrupted_sync.py
@@ -30,7 +30,7 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
         resp = requests.post("https://api.hubapi.com/oauth/v1/token", data=payload)
         return resp.json()['access_token']
 
-    def ensure_ticket(self):
+    def ensure_ticket(self, headers):
         ticket = [
             {
                 'name': 'subject',

--- a/tests/test_hubspot_interrupted_sync.py
+++ b/tests/test_hubspot_interrupted_sync.py
@@ -133,6 +133,8 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
         state_1 = menagerie.get_state(conn_id)
 
         # Update state to simulate a bookmark
+        self.ensure_engagement()
+        self.ensure_ticket()
         new_state = self.simulated_interruption(state_1)
         menagerie.set_state(conn_id, new_state)
 
@@ -143,10 +145,6 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
 
         # Test by Stream
         for stream in expected_streams:
-            if (stream == 'engagements'):
-                self.ensure_engagement()
-            elif (stream == 'tickets'):
-                self.ensure_ticket()
 
             with self.subTest(stream=stream):
 

--- a/tests/test_hubspot_interrupted_sync.py
+++ b/tests/test_hubspot_interrupted_sync.py
@@ -31,12 +31,6 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
         return resp.json()['access_token']
 
     def ensure_ticket(self):
-        access_token = self.get_access_token()
-        headers = {
-            'authorization': f'Bearer {access_token}',
-            'content-type': 'application/json'
-        }
-
         ticket = [
             {
                 'name': 'subject',
@@ -53,13 +47,7 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
         ]
         requests.post('https://api.hubapi.com/crm-objects/v1/objects/tickets', json=ticket, headers=headers)
 
-    def ensure_engagement(self):
-        access_token = self.get_access_token()
-        headers = {
-            'authorization': f'Bearer {access_token}',
-            'content-type': 'application/json'
-        }
-
+    def ensure_engagement(self, headers):
         engagement = {
             'engagement': {
                 'type': 'EMAIL',
@@ -68,6 +56,15 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
             'metadata': {}
         }
         requests.post('https://api.hubapi.com/engagements/v1/engagements', json=engagement, headers=headers)
+
+    def ensure_engagement_and_ticket(self):
+        access_token = self.get_access_token()
+        headers = {
+            'authorization': f'Bearer {access_token}',
+            'content-type': 'application/json'
+        }
+        self.ensure_engagement(headers)
+        self.ensure_ticket(headers)
 
     def simulated_interruption(self, reference_state):
 
@@ -128,13 +125,12 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
             )
 
         # Run sync 1
+        self.ensure_engagement_and_ticket()
         first_record_count_by_stream = self.run_and_verify_sync(conn_id)
         synced_records = runner.get_records_from_target_output()
         state_1 = menagerie.get_state(conn_id)
 
         # Update state to simulate a bookmark
-        self.ensure_engagement()
-        self.ensure_ticket()
         new_state = self.simulated_interruption(state_1)
         menagerie.set_state(conn_id, new_state)
 

--- a/tests/test_hubspot_interrupted_sync.py
+++ b/tests/test_hubspot_interrupted_sync.py
@@ -30,7 +30,7 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
         resp = requests.post("https://api.hubapi.com/oauth/v1/token", data=payload)
         return resp.json()['access_token']
 
-    def ensure_ticket(self, headers):
+    def ensure_ticket(self):
         access_token = self.get_access_token()
         headers = {
             'authorization': f'Bearer {access_token}',
@@ -53,7 +53,7 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
         ]
         requests.post('https://api.hubapi.com/crm-objects/v1/objects/tickets', json=ticket, headers=headers)
 
-    def ensure_engagement(self, headers):
+    def ensure_engagement(self):
         access_token = self.get_access_token()
         headers = {
             'authorization': f'Bearer {access_token}',

--- a/tests/test_hubspot_interrupted_sync.py
+++ b/tests/test_hubspot_interrupted_sync.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from time import sleep
 import copy
+import requests
 
 import tap_tester.connections as connections
 import tap_tester.menagerie   as menagerie
@@ -19,6 +20,51 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
     def streams_to_test(self):
         """expected streams minus the streams not under test"""
         return {'companies', 'contacts', 'tickets', 'engagements'}
+
+    def ensure_tickets_and_engagements(self):
+        access_token = self.get_access_token()
+        headers = {
+            'authorization': f'Bearer {access_token}',
+            'content-type': 'application/json'
+        }
+
+        engagement = {
+            'engagement': {
+                'type': 'EMAIL',
+                'active': True
+            },
+            'metadata': {}
+        }
+        requests.post('https://api.hubapi.com/engagements/v1/engagements', json=engagement, headers=headers)
+
+        ticket = [
+            {
+                'name': 'subject',
+                'value': 'Example ticket subject'
+            },
+            {
+                'name': 'hs_pipeline',
+                'value': '0'
+            },
+            {
+                'name': 'hs_pipeline_stage',
+                'value': '1'
+            }
+        ]
+        requests.post('https://api.hubapi.com/crm-objects/v1/objects/tickets', json=ticket, headers=headers)
+
+    def get_access_token(self):
+        creds = self.get_credentials()
+        payload = {
+            "grant_type": "refresh_token",
+            "redirect_uri": creds['redirect_uri'],
+            "refresh_token": creds['refresh_token'],
+            "client_id": creds['client_id'],
+            "client_secret": creds['client_secret']
+        }
+
+        resp = requests.post("https://api.hubapi.com/oauth/v1/token", data=payload)
+        return resp.json()['access_token']
 
     def simulated_interruption(self, reference_state):
 
@@ -52,12 +98,12 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
 
     def get_properties(self):
         #        'start_date' : '2021-08-19T00:00:00Z'
-        return {'start_date' : '2017-11-22T00:00:00Z'}
-        # return {
-        #     'start_date' : datetime.strftime(
-        #         datetime.today()-timedelta(days=5), self.START_DATE_FORMAT
-        #     ),
-        # }
+        # return {'start_date' : '2017-11-22T00:00:00Z'}
+        return {
+            'start_date' : datetime.strftime(
+                datetime.today()-timedelta(days=5), self.START_DATE_FORMAT
+            ),
+        }
 
     def setUp(self):
         self.maxDiff = None  # see all output in failure
@@ -81,6 +127,7 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
             )
 
         # Run sync 1
+        self.ensure_tickets_and_engagements()
         first_record_count_by_stream = self.run_and_verify_sync(conn_id)
         synced_records = runner.get_records_from_target_output()
         state_1 = menagerie.get_state(conn_id)

--- a/tests/test_hubspot_interrupted_sync.py
+++ b/tests/test_hubspot_interrupted_sync.py
@@ -21,21 +21,21 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
         """expected streams minus the streams not under test"""
         return {'companies', 'contacts', 'tickets', 'engagements'}
 
-    def ensure_tickets_and_engagements(self):
+    def get_access_token(self):
+        payload = {
+            'grant_type': 'refresh_token'
+        }
+        payload.update(self.get_credentials())
+
+        resp = requests.post("https://api.hubapi.com/oauth/v1/token", data=payload)
+        return resp.json()['access_token']
+
+    def ensure_ticket(self, headers):
         access_token = self.get_access_token()
         headers = {
             'authorization': f'Bearer {access_token}',
             'content-type': 'application/json'
         }
-
-        engagement = {
-            'engagement': {
-                'type': 'EMAIL',
-                'active': True
-            },
-            'metadata': {}
-        }
-        requests.post('https://api.hubapi.com/engagements/v1/engagements', json=engagement, headers=headers)
 
         ticket = [
             {
@@ -53,18 +53,21 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
         ]
         requests.post('https://api.hubapi.com/crm-objects/v1/objects/tickets', json=ticket, headers=headers)
 
-    def get_access_token(self):
-        creds = self.get_credentials()
-        payload = {
-            "grant_type": "refresh_token",
-            "redirect_uri": creds['redirect_uri'],
-            "refresh_token": creds['refresh_token'],
-            "client_id": creds['client_id'],
-            "client_secret": creds['client_secret']
+    def ensure_enagement(self, headers):
+        access_token = self.get_access_token()
+        headers = {
+            'authorization': f'Bearer {access_token}',
+            'content-type': 'application/json'
         }
 
-        resp = requests.post("https://api.hubapi.com/oauth/v1/token", data=payload)
-        return resp.json()['access_token']
+        engagement = {
+            'engagement': {
+                'type': 'EMAIL',
+                'active': True
+            },
+            'metadata': {}
+        }
+        requests.post('https://api.hubapi.com/engagements/v1/engagements', json=engagement, headers=headers)
 
     def simulated_interruption(self, reference_state):
 
@@ -97,8 +100,6 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
         return new_state
 
     def get_properties(self):
-        #        'start_date' : '2021-08-19T00:00:00Z'
-        # return {'start_date' : '2017-11-22T00:00:00Z'}
         return {
             'start_date' : datetime.strftime(
                 datetime.today()-timedelta(days=5), self.START_DATE_FORMAT
@@ -127,7 +128,6 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
             )
 
         # Run sync 1
-        self.ensure_tickets_and_engagements()
         first_record_count_by_stream = self.run_and_verify_sync(conn_id)
         synced_records = runner.get_records_from_target_output()
         state_1 = menagerie.get_state(conn_id)
@@ -143,6 +143,10 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
 
         # Test by Stream
         for stream in expected_streams:
+            if (stream == 'engagements'):
+                self.ensure_engagement()
+            elif (stream == 'tickets'):
+                self.ensure_ticket()
 
             with self.subTest(stream=stream):
 

--- a/tests/test_hubspot_interrupted_sync.py
+++ b/tests/test_hubspot_interrupted_sync.py
@@ -53,7 +53,7 @@ class TestHubspotInterruptedSync1(HubspotBaseTest):
         ]
         requests.post('https://api.hubapi.com/crm-objects/v1/objects/tickets', json=ticket, headers=headers)
 
-    def ensure_enagement(self, headers):
+    def ensure_engagement(self, headers):
         access_token = self.get_access_token()
         headers = {
             'authorization': f'Bearer {access_token}',


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-30347
Adds `tickets` and `engagements` back to interrupted sync test. Fixes issue with test failures by creating one of each before syncing.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
