### PR TITLE
  Switch engagements sync from /paged to /recent/modified for server-side incremental filtering

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -91,7 +91,7 @@ ENDPOINTS = {
     "campaigns_all":        "/email/public/v1/campaigns/by-id",
     "campaigns_detail":     "/email/public/v1/campaigns/{campaign_id}",
 
-    "engagements_all":        "/engagements/v1/engagements/paged",
+    "engagements_all":        "/engagements/v1/engagements/recent/modified",
 
     "subscription_changes": "/email/public/v1/subscriptions/timeline",
     "email_events":         "/email/public/v1/events",
@@ -1113,7 +1113,11 @@ def sync_engagements(STATE, ctx):
     singer.write_state(STATE)
 
     url = get_url("engagements_all")
-    params = {'limit': int(CONFIG.get('engagements_page_size') or 190)}
+    since_ts = int(utils.strptime_to_utc(start).timestamp() * 1000)
+    params = {
+        'count': int(CONFIG.get('engagements_page_size') or 190),
+        'since': since_ts,
+    }
     top_level_key = "results"
     engagements = gen_request(STATE, 'engagements', url, params, top_level_key, "hasMore", ["offset"], ["offset"])
 

--- a/tap_hubspot/tests/unittests/test_engagements.py
+++ b/tap_hubspot/tests/unittests/test_engagements.py
@@ -1,0 +1,195 @@
+import json
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+from datetime import datetime, timezone
+
+from tap_hubspot import sync_engagements
+
+
+_SCHEMA_PATH = os.path.join(os.path.dirname(__file__), '..', '..', 'schemas', 'engagements.json')
+with open(_SCHEMA_PATH) as _f:
+    ENGAGEMENTS_SCHEMA = json.load(_f)
+
+
+def make_engagement(eid, last_updated_millis):
+    return {
+        "engagement": {
+            "id": eid,
+            "lastUpdated": last_updated_millis,
+            "type": "NOTE"
+        },
+        "associations": {"contactIds": [], "companyIds": [], "dealIds": []},
+        "attachments": [],
+        "metadata": {"body": "test"}
+    }
+
+
+class TestSyncEngagements(unittest.TestCase):
+    def make_ctx(self):
+        mock_ctx = MagicMock()
+        mock_ctx.get_catalog_from_id.return_value = {
+            "metadata": [],
+            "stream_alias": None
+        }
+        return mock_ctx
+
+    @patch('singer.write_state')
+    @patch('singer.write_schema')
+    @patch('singer.utils.strptime_to_utc')
+    @patch('singer.utils.strftime')
+    @patch('tap_hubspot.utils.now')
+    @patch('tap_hubspot.get_current_sync_start', return_value=None)
+    @patch('tap_hubspot.get_start', return_value='2023-01-01T00:00:00.000000Z')
+    @patch('tap_hubspot.load_schema', return_value=ENGAGEMENTS_SCHEMA)
+    @patch('tap_hubspot.gen_request', return_value=[])
+    def test_gen_request_called_with_correct_url_and_params(
+        self, mock_gen_request, mock_load_schema, mock_get_start,
+        mock_get_current_sync_start, mock_now, mock_strftime, mock_strptime_to_utc,
+        mock_write_schema, mock_write_state
+    ):
+        state = {"currently_syncing": "engagements"}
+        mock_now.return_value = datetime(2023, 12, 1, tzinfo=timezone.utc)
+        mock_strftime.return_value = '2023-01-01T00:00:00.000000Z'
+        mock_strptime_to_utc.return_value = datetime(2023, 1, 1, tzinfo=timezone.utc)
+
+        sync_engagements(state, self.make_ctx())
+
+        args = mock_gen_request.call_args[0]
+        self.assertEqual(args[1:], (
+            'engagements',
+            'https://api.hubapi.com/engagements/v1/engagements/paged',
+            {'limit': 190},
+            'results',
+            'hasMore',
+            ['offset'],
+            ['offset']
+        ))
+
+    @patch('singer.write_state')
+    @patch('singer.write_schema')
+    @patch('singer.utils.strptime_to_utc')
+    @patch('singer.utils.strftime')
+    @patch('tap_hubspot.utils.now')
+    @patch('tap_hubspot.get_current_sync_start', return_value=None)
+    @patch('tap_hubspot.get_start', return_value='2023-01-01T00:00:00.000000Z')
+    @patch('tap_hubspot.load_schema', return_value=ENGAGEMENTS_SCHEMA)
+    @patch('tap_hubspot.gen_request', return_value=[])
+    def test_engagements_page_size_config_option(
+        self, mock_gen_request, mock_load_schema, mock_get_start,
+        mock_get_current_sync_start, mock_now, mock_strftime, mock_strptime_to_utc,
+        mock_write_schema, mock_write_state
+    ):
+        state = {"currently_syncing": "engagements"}
+        mock_now.return_value = datetime(2023, 12, 1, tzinfo=timezone.utc)
+        mock_strftime.return_value = '2023-01-01T00:00:00.000000Z'
+        mock_strptime_to_utc.return_value = datetime(2023, 1, 1, tzinfo=timezone.utc)
+
+        with patch.dict('tap_hubspot.CONFIG', {'engagements_page_size': 100}, clear=False):
+            sync_engagements(state, self.make_ctx())
+
+        args = mock_gen_request.call_args[0]
+        self.assertEqual(args[3], {'limit': 100})
+
+    @patch('singer.write_record')
+    @patch('singer.write_state')
+    @patch('singer.write_schema')
+    @patch('tap_hubspot.utils.now')
+    @patch('tap_hubspot.get_current_sync_start', return_value=None)
+    @patch('tap_hubspot.get_start', return_value='2023-06-01T00:00:00.000000Z')
+    @patch('tap_hubspot.load_schema', return_value=ENGAGEMENTS_SCHEMA)
+    @patch('tap_hubspot.gen_request')
+    def test_records_before_bookmark_are_filtered_out(
+        self, mock_gen_request, mock_load_schema, mock_get_start,
+        mock_get_current_sync_start, mock_now, mock_write_schema,
+        mock_write_state, mock_write_record
+    ):
+        state = {"currently_syncing": "engagements"}
+        mock_now.return_value = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        mock_gen_request.return_value = [
+            make_engagement(1, 1672531200000),  # 2023-01-01
+            make_engagement(2, 1696118400000),  # 2023-10-01
+        ]
+
+        sync_engagements(state, self.make_ctx())
+
+        self.assertEqual(mock_write_record.call_count, 1)
+        written_record = mock_write_record.call_args[0][1]
+        self.assertEqual(written_record['engagement']['id'], 2)
+
+    @patch('singer.write_record')
+    @patch('singer.write_state')
+    @patch('singer.write_schema')
+    @patch('tap_hubspot.utils.now')
+    @patch('tap_hubspot.get_current_sync_start', return_value=None)
+    @patch('tap_hubspot.get_start', return_value='2023-01-01T00:00:00.000000Z')
+    @patch('tap_hubspot.load_schema', return_value=ENGAGEMENTS_SCHEMA)
+    @patch('tap_hubspot.gen_request')
+    def test_bookmark_capped_at_sync_start(
+        self, mock_gen_request, mock_load_schema, mock_get_start,
+        mock_get_current_sync_start, mock_now, mock_write_schema,
+        mock_write_state, mock_write_record
+    ):
+        state = {"currently_syncing": "engagements"}
+        sync_start = datetime(2023, 9, 1, tzinfo=timezone.utc)
+        mock_now.return_value = sync_start
+        mock_gen_request.return_value = [
+            make_engagement(1, 1696118400000),  # 2023-10-01
+        ]
+
+        result_state = sync_engagements(state, self.make_ctx())
+
+        bk_value = result_state['bookmarks']['engagements']['lastUpdated']
+        self.assertEqual(bk_value, '2023-09-01T00:00:00.000000Z')
+        self.assertIsNone(result_state['bookmarks']['engagements']['current_sync_start'])
+
+    @patch('singer.write_record')
+    @patch('singer.write_state')
+    @patch('singer.write_schema')
+    @patch('tap_hubspot.utils.now')
+    @patch('tap_hubspot.get_current_sync_start', return_value=None)
+    @patch('tap_hubspot.get_start', return_value='2023-01-01T00:00:00.000000Z')
+    @patch('tap_hubspot.load_schema', return_value=ENGAGEMENTS_SCHEMA)
+    @patch('tap_hubspot.gen_request', return_value=[])
+    def test_empty_result_set(
+        self, mock_gen_request, mock_load_schema, mock_get_start,
+        mock_get_current_sync_start, mock_now, mock_write_schema,
+        mock_write_state, mock_write_record
+    ):
+        state = {"currently_syncing": "engagements"}
+        mock_now.return_value = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+        result_state = sync_engagements(state, self.make_ctx())
+
+        mock_write_record.assert_not_called()
+        bk_value = result_state['bookmarks']['engagements']['lastUpdated']
+        self.assertEqual(bk_value, '2023-01-01T00:00:00.000000Z')
+
+    @patch('singer.write_record')
+    @patch('singer.write_state')
+    @patch('singer.write_schema')
+    @patch('tap_hubspot.utils.now')
+    @patch('tap_hubspot.get_current_sync_start', return_value=None)
+    @patch('tap_hubspot.get_start', return_value='2023-01-01T00:00:00.000000Z')
+    @patch('tap_hubspot.load_schema', return_value=ENGAGEMENTS_SCHEMA)
+    @patch('tap_hubspot.gen_request')
+    def test_record_hoists_engagement_id_and_lastUpdated(
+        self, mock_gen_request, mock_load_schema, mock_get_start,
+        mock_get_current_sync_start, mock_now, mock_write_schema,
+        mock_write_state, mock_write_record
+    ):
+        state = {"currently_syncing": "engagements"}
+        mock_now.return_value = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        mock_gen_request.return_value = [
+            make_engagement(42, 1696118400000),  # 2023-10-01
+        ]
+
+        sync_engagements(state, self.make_ctx())
+
+        written_record = mock_write_record.call_args[0][1]
+        self.assertEqual(written_record['engagement_id'], 42)
+        self.assertIn('lastUpdated', written_record)
+        self.assertEqual(
+            written_record['lastUpdated'],
+            written_record['engagement']['lastUpdated']
+        )

--- a/tap_hubspot/tests/unittests/test_engagements.py
+++ b/tap_hubspot/tests/unittests/test_engagements.py
@@ -56,15 +56,15 @@ class TestSyncEngagements(unittest.TestCase):
         sync_engagements(state, self.make_ctx())
 
         args = mock_gen_request.call_args[0]
-        self.assertEqual(args[1:], (
-            'engagements',
-            'https://api.hubapi.com/engagements/v1/engagements/paged',
-            {'limit': 190},
-            'results',
-            'hasMore',
-            ['offset'],
-            ['offset']
-        ))
+        self.assertEqual(args[1], 'engagements')
+        self.assertEqual(args[2], 'https://api.hubapi.com/engagements/v1/engagements/recent/modified')
+        self.assertIn('count', args[3])
+        self.assertEqual(args[3]['count'], 190)
+        self.assertIn('since', args[3])
+        self.assertEqual(args[4], 'results')
+        self.assertEqual(args[5], 'hasMore')
+        self.assertEqual(args[6], ['offset'])
+        self.assertEqual(args[7], ['offset'])
 
     @patch('singer.write_state')
     @patch('singer.write_schema')
@@ -89,7 +89,31 @@ class TestSyncEngagements(unittest.TestCase):
             sync_engagements(state, self.make_ctx())
 
         args = mock_gen_request.call_args[0]
-        self.assertEqual(args[3], {'limit': 100})
+        self.assertEqual(args[3]['count'], 100)
+
+    @patch('singer.write_state')
+    @patch('singer.write_schema')
+    @patch('singer.utils.strptime_to_utc')
+    @patch('singer.utils.strftime')
+    @patch('tap_hubspot.utils.now')
+    @patch('tap_hubspot.get_current_sync_start', return_value=None)
+    @patch('tap_hubspot.get_start', return_value='2023-06-15T00:00:00.000000Z')
+    @patch('tap_hubspot.load_schema', return_value=ENGAGEMENTS_SCHEMA)
+    @patch('tap_hubspot.gen_request', return_value=[])
+    def test_since_param_derived_from_bookmark(
+        self, mock_gen_request, mock_load_schema, mock_get_start,
+        mock_get_current_sync_start, mock_now, mock_strftime, mock_strptime_to_utc,
+        mock_write_schema, mock_write_state
+    ):
+        state = {"currently_syncing": "engagements"}
+        mock_now.return_value = datetime(2023, 12, 1, tzinfo=timezone.utc)
+        mock_strftime.return_value = '2023-06-15T00:00:00.000000Z'
+        mock_strptime_to_utc.return_value = datetime(2023, 6, 15, tzinfo=timezone.utc)
+
+        sync_engagements(state, self.make_ctx())
+
+        args = mock_gen_request.call_args[0]
+        self.assertEqual(args[3]['since'], 1686787200000)
 
     @patch('singer.write_record')
     @patch('singer.write_state')


### PR DESCRIPTION
# Description of change
*Submitted on behalf of HubSpot Engineering *

Switches the engagements sync from `/engagements/v1/engagements/paged` to `/engagements/v1/engagements/recent/modified` for server-side incremental filtering.

**Why:** Today, every engagements sync downloads the entire dataset via `/paged` and filters client-side against the bookmark. For portals with large engagement volumes this means re-downloading millions of records per run just to discard most of them. The `/recent/modified` endpoint accepts a `since` parameter (epoch millis) and only returns engagements modified after that timestamp, so the API does the filtering. 

**What changed:**
- `ENDPOINTS["engagements_all"]`: `/engagements/v1/engagements/paged` → `/engagements/v1/engagements/recent/modified`
- `sync_engagements()` params: `{'limit': N}` → `{'count': N, 'since': <bookmark_as_epoch_millis>}`


# Manual QA steps
 - Run `tap-hubspot -c config.json --properties catalog.json` without state: all engagements returned
 - Run with `--state state.json`: only recently modified engagements returned
 - Verify endpoint in metrics log shows `/recent/modified` not `/paged`

### Backward compatibility:
  - Both endpoints return the same response shape (`results` array, `hasMore`, `offset`), so `gen_request()` pagination works unchanged
  - Record structure is identical — same `engagement`, `associations`, `attachments`, `metadata` fields — so the schema and Transformer logic are unaffected
  - Verified against live API: both endpoints return the same engagement objects with the same field names and types
  - Client-side bookmark filter (`record['engagement']['lastUpdated'] >= start`) retained as a safety check
  - Existing state/bookmarks work as-is — `lastUpdated` bookmark is converted to epoch millis for the `since` param
  - `engagements_page_size` config option still honored (mapped to `count` instead of `limit`)
  - First sync (no state) uses `start_date` from config, converted to epoch millis — behaves the same as before

# Risks
 - `/recent/modified` may have a time window cap on how far back `since` can go — could affect very stale bookmarks
 - Response ordering changed (newest-first vs oldest-first) — no impact since we track max bookmark regardless

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [x] this PR has been written with the help of GitHub Copilot or another generative AI tool
