### PR TITLE
fix: map empty string v3 properties to None to preserve null for boolean fields

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -358,7 +358,9 @@ def request(url, params=None):
 def lift_properties_and_versions(record):
     for key, value in record.get('properties', {}).items():
         computed_key = "property_{}".format(key)
-        record[computed_key] = value
+        # The v3 API returns "" for unset properties; map to None so the Singer
+        # Transformer coerces them to null rather than false for boolean fields.
+        record[computed_key] = None if value == "" else value
         if isinstance(value, dict):
             versions = value.get('versions')
             if versions:


### PR DESCRIPTION
## Summary

- The contacts stream was migrated to the v3 API endpoint (`/crm/v3/objects/contacts`), which returns flat string key-value pairs for properties instead of nested objects.
- When a property is **not set** in HubSpot, the v3 API returns an empty string `""` rather than omitting the key.
- `lift_properties_and_versions` was lifting those empty strings as-is, so the Singer `Transformer` received `""` for fields typed `["null", "boolean"]` and coerced them to `false` instead of `null`.
- This caused all unset boolean custom fields (e.g. `property_ab_test_mail_onboarding_04_26`) to silently change from `null` to `false` after the v3 migration, breaking downstream data accuracy.

**Fix:** in `lift_properties_and_versions`, map `"" → None` before lifting so the Transformer produces `null` for unset properties across all field types.

## Test plan

- [ ] Sync contacts with at least one boolean custom property that is unset for some records; confirm those records land as `null` (not `false`) in the destination.
- [ ] Confirm records where the boolean is explicitly `true` or `false` in HubSpot are still written correctly.
- [ ] Confirm string and datetime custom properties are unaffected (empty string from API → `null` in destination, consistent with prior behaviour on unset fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
