### PR TITLE
 Migrate engagements sync from /paged to /modified/after cursor-based pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.4.0
+  * Migrate engagements sync from `/paged` to `/engagements/v1/engagements/modified/after` with opaque cursor-based pagination for incremental, crash-safe resume.
+
 ## 4.3.0
   * Always write bookmarks for form_submissions and list_memberships streams, even when there are no records. [#292](https://github.com/singer-io/tap-hubspot/pull/292)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-hubspot',
-      version='4.3.0',
+      version='4.4.0',
       description='Singer.io tap for extracting data from the HubSpot API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -144,18 +144,17 @@ def write_current_sync_start(state, tap_stream_id, start):
     return singer.write_bookmark(state, tap_stream_id, "current_sync_start", value)
 
 def get_engagements_cursor(state, start):
-    offset = singer.get_offset(state, 'engagements') or {}
-    if offset.get('cursor'):
-        return offset['cursor']
-
+    # Continue from the opaque cursor written after a successful modified/after sync.
     cursor = singer.get_bookmark(state, 'engagements', 'cursor')
     if cursor:
         return cursor
 
+    # Support older state that stored the modified/after cursor as the after bookmark.
     previous_after = singer.get_bookmark(state, 'engagements', 'after')
     if previous_after:
         return previous_after
 
+    # Migrate timestamp-based state by seeding modified/after with epoch millis.
     return int(utils.strptime_to_utc(start).timestamp() * 1000)
 
 def clean_state(state):
@@ -1145,12 +1144,8 @@ def sync_engagements(STATE, ctx):
                 if not data.get('hasMore', False):
                     break
 
-                STATE = singer.clear_offset(STATE, 'engagements')
                 params['after'] = cursor
-                STATE = singer.set_offset(STATE, 'engagements', 'cursor', cursor)
-                singer.write_state(STATE)
 
-    STATE = singer.clear_offset(STATE, 'engagements')
     STATE = singer.write_bookmark(STATE, 'engagements', 'cursor', cursor)
     STATE = singer.clear_bookmark(STATE, 'engagements', bookmark_key)
     STATE = singer.clear_bookmark(STATE, 'engagements', 'after')

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -1117,7 +1117,13 @@ def sync_engagements(STATE, ctx):
     LOGGER.info("sync_engagements from %s", start)
 
     url = get_url("engagements_modified_after")
-    cursor = get_engagements_cursor(STATE, start)
+
+    inflight = singer.get_offset(STATE, 'engagements')
+    if inflight and inflight.get('after'):
+        cursor = inflight['after']
+    else:
+        cursor = get_engagements_cursor(STATE, start)
+
     params = {
         'limit': int(CONFIG.get('engagements_page_size') or 190),
         'after': cursor,
@@ -1148,8 +1154,12 @@ def sync_engagements(STATE, ctx):
                     break
 
                 params['after'] = cursor
+                STATE = singer.set_offset(STATE, 'engagements', 'after', cursor)
+                singer.write_state(STATE)
+
             LOGGER.info('Fetched %d engagements records', counter.value)
 
+    STATE = singer.clear_offset(STATE, 'engagements')
     STATE = singer.write_bookmark(STATE, 'engagements', 'cursor', cursor)
     STATE = singer.clear_bookmark(STATE, 'engagements', bookmark_key)
     STATE = singer.clear_bookmark(STATE, 'engagements', 'after')

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -91,7 +91,6 @@ ENDPOINTS = {
     "campaigns_all":        "/email/public/v1/campaigns/by-id",
     "campaigns_detail":     "/email/public/v1/campaigns/{campaign_id}",
 
-    "engagements_all":        "/engagements/v1/engagements/paged",
     "engagements_modified_after": "/engagements/v1/engagements/modified/after",
 
     "subscription_changes": "/email/public/v1/subscriptions/timeline",

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -768,7 +768,9 @@ def sync_v3_stream(STATE, ctx, stream_id, params, primary_key="id", bookmark_key
         # store the current sync start in the state and not move the bookmark past this value.
         sync_start_time = utils.now()
         with metrics.record_counter(stream_id) as counter:
+            raw_count = 0
             for row in get_v3_records(url, params, 'results', "paging"):
+                raw_count += 1
                 modified_time = utils.strptime_to_utc(row[bookmark_key])
 
                 if modified_time and modified_time >= bookmark_value:
@@ -778,6 +780,7 @@ def sync_v3_stream(STATE, ctx, stream_id, params, primary_key="id", bookmark_key
                     if modified_time >= max_bk_value:
                         max_bk_value = modified_time
                     counter.increment()
+            LOGGER.info("Fetched %d raw %s records, emitted %d after incremental filter", raw_count, stream_id, counter.value)
 
     # Don't bookmark past the start of this sync to account for updated records during the sync.
     new_bookmark = min(max_bk_value, sync_start_time)
@@ -1145,6 +1148,7 @@ def sync_engagements(STATE, ctx):
                     break
 
                 params['after'] = cursor
+            LOGGER.info('Fetched %d engagements records', counter.value)
 
     STATE = singer.write_bookmark(STATE, 'engagements', 'cursor', cursor)
     STATE = singer.clear_bookmark(STATE, 'engagements', bookmark_key)

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -92,6 +92,7 @@ ENDPOINTS = {
     "campaigns_detail":     "/email/public/v1/campaigns/{campaign_id}",
 
     "engagements_all":        "/engagements/v1/engagements/paged",
+    "engagements_modified_after": "/engagements/v1/engagements/modified/after",
 
     "subscription_changes": "/email/public/v1/subscriptions/timeline",
     "email_events":         "/email/public/v1/events",
@@ -141,6 +142,21 @@ def write_current_sync_start(state, tap_stream_id, start):
     if start is not None:
         value = utils.strftime(start)
     return singer.write_bookmark(state, tap_stream_id, "current_sync_start", value)
+
+def get_engagements_cursor(state, start):
+    offset = singer.get_offset(state, 'engagements') or {}
+    if offset.get('cursor'):
+        return offset['cursor']
+
+    cursor = singer.get_bookmark(state, 'engagements', 'cursor')
+    if cursor:
+        return cursor
+
+    previous_after = singer.get_bookmark(state, 'engagements', 'after')
+    if previous_after:
+        return previous_after
+
+    return int(utils.strptime_to_utc(start).timestamp() * 1000)
 
 def clean_state(state):
     """ Clear deprecated keys out of state. """
@@ -1096,44 +1112,49 @@ def sync_engagements(STATE, ctx):
     singer.write_schema("engagements", schema, ["engagement_id"], [bookmark_key], catalog.get('stream_alias'))
     start = get_start(STATE, "engagements", bookmark_key)
 
-    # Because this stream doesn't query by `lastUpdated`, it cycles
-    # through the data set every time. The issue with this is that there
-    # is a race condition by which records may be updated between the
-    # start of this table's sync and the end, causing some updates to not
-    # be captured, in order to combat this, we must store the current
-    # sync's start in the state and not move the bookmark past this value.
-    current_sync_start = get_current_sync_start(STATE, "engagements") or utils.now()
-    STATE = write_current_sync_start(STATE, "engagements", current_sync_start)
-    singer.write_state(STATE)
-
-    max_bk_value = start
     LOGGER.info("sync_engagements from %s", start)
 
-    STATE = singer.write_bookmark(STATE, 'engagements', bookmark_key, start)
-    singer.write_state(STATE)
-
-    url = get_url("engagements_all")
-    params = {'limit': int(CONFIG.get('engagements_page_size') or 190)}
+    url = get_url("engagements_modified_after")
+    cursor = get_engagements_cursor(STATE, start)
+    params = {
+        'limit': int(CONFIG.get('engagements_page_size') or 190),
+        'after': cursor,
+    }
     top_level_key = "results"
-    engagements = gen_request(STATE, 'engagements', url, params, top_level_key, "hasMore", ["offset"], ["offset"])
 
     time_extracted = utils.now()
 
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
-        for engagement in engagements:
-            record = bumble_bee.transform(lift_properties_and_versions(engagement), schema, mdata)
-            if record['engagement'][bookmark_key] >= start:
-                # hoist PK and bookmark field to top-level record
-                record['engagement_id'] = record['engagement']['id']
-                record[bookmark_key] = record['engagement'][bookmark_key]
-                singer.write_record("engagements", record, catalog.get('stream_alias'), time_extracted=time_extracted)
-                if record['engagement'][bookmark_key] >= max_bk_value:
-                    max_bk_value = record['engagement'][bookmark_key]
+        with metrics.record_counter('engagements') as counter:
+            while True:
+                data = request(url, dict(params)).json()
 
-    # Don't bookmark past the start of this sync to account for updated records during the sync.
-    new_bookmark = min(utils.strptime_to_utc(max_bk_value), current_sync_start)
-    STATE = singer.write_bookmark(STATE, 'engagements', bookmark_key, utils.strftime(new_bookmark))
-    STATE = write_current_sync_start(STATE, 'engagements', None)
+                if data.get(top_level_key) is None:
+                    raise RuntimeError("Unexpected API response: {} not in {}".format(top_level_key, data.keys()))
+
+                cursor = data.get('after', cursor)
+
+                for engagement in data[top_level_key]:
+                    counter.increment()
+                    record = bumble_bee.transform(lift_properties_and_versions(engagement), schema, mdata)
+                    if start is None or record['engagement'][bookmark_key] >= start:
+                        record['engagement_id'] = record['engagement']['id']
+                        record[bookmark_key] = record['engagement'][bookmark_key]
+                        singer.write_record("engagements", record, catalog.get('stream_alias'), time_extracted=time_extracted)
+
+                if not data.get('hasMore', False):
+                    break
+
+                STATE = singer.clear_offset(STATE, 'engagements')
+                params['after'] = cursor
+                STATE = singer.set_offset(STATE, 'engagements', 'cursor', cursor)
+                singer.write_state(STATE)
+
+    STATE = singer.clear_offset(STATE, 'engagements')
+    STATE = singer.write_bookmark(STATE, 'engagements', 'cursor', cursor)
+    STATE = singer.clear_bookmark(STATE, 'engagements', bookmark_key)
+    STATE = singer.clear_bookmark(STATE, 'engagements', 'after')
+    STATE = singer.clear_bookmark(STATE, 'engagements', 'current_sync_start')
     singer.write_state(STATE)
     return STATE
 
@@ -1370,7 +1391,6 @@ def do_sync(STATE, catalog):
         deselect_unselected_fields(catalog)
 
     custom_objects = generate_custom_streams(mode="SYNC", catalog=catalog)
-    # Clear out keys that are no longer used
     clean_state(STATE)
 
     ctx = Context(catalog)

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -1142,12 +1142,12 @@ def sync_engagements(STATE, ctx):
                 cursor = data.get('after', cursor)
 
                 for engagement in data[top_level_key]:
-                    counter.increment()
                     record = bumble_bee.transform(lift_properties_and_versions(engagement), schema, mdata)
                     if start is None or record['engagement'][bookmark_key] >= start:
                         record['engagement_id'] = record['engagement']['id']
                         record[bookmark_key] = record['engagement'][bookmark_key]
                         singer.write_record("engagements", record, catalog.get('stream_alias'), time_extracted=time_extracted)
+                        counter.increment()
 
                 if not data.get('hasMore', False):
                     break

--- a/tap_hubspot/tests/unittests/test_engagements.py
+++ b/tap_hubspot/tests/unittests/test_engagements.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import unittest
@@ -124,3 +125,40 @@ class TestSyncEngagements(unittest.TestCase):
             singer.get_bookmark(result, 'engagements', 'cursor'),
             'cursor-page-2'
         )
+
+    @patch('singer.write_schema')
+    @patch('tap_hubspot.request')
+    @patch('tap_hubspot.get_start', return_value='2023-01-01T00:00:00.000000Z')
+    def test_offset_persists_page_one_cursor_before_fetching_page_two(
+        self, mock_get_start, mock_request, mock_write_schema
+    ):
+        # Crash-recovery guarantee: after emitting page 1 we must persist the
+        # cursor that fetches page 2, so an interrupted run resumes there
+        # instead of re-reading from the last completed sync.
+        mock_request.side_effect = [
+            make_response([], has_more=True, after="cursor-page-1"),
+            make_response([], has_more=False, after="cursor-page-2"),
+        ]
+        state = {"bookmarks": {"engagements": {}}}
+
+        snapshots = []
+        with patch('singer.write_state', side_effect=lambda s: snapshots.append(copy.deepcopy(s))):
+            sync_engagements(state, self.make_ctx())
+
+        # An intermediate state must have carried the page-1 cursor as the
+        # in-flight offset (this is the page-2 request cursor).
+        intermediate_offsets = [
+            singer.get_offset(s, 'engagements')
+            for s in snapshots
+            if singer.get_offset(s, 'engagements')
+        ]
+        self.assertIn({'after': 'cursor-page-1'}, intermediate_offsets)
+
+        # The page-2 request must have actually used that persisted cursor.
+        page_two_params = mock_request.call_args_list[1][0][1]
+        self.assertEqual(page_two_params['after'], 'cursor-page-1')
+
+        # Final persisted state: offset cleared, durable cursor advanced.
+        final = snapshots[-1]
+        self.assertIsNone(singer.get_offset(final, 'engagements'))
+        self.assertEqual(singer.get_bookmark(final, 'engagements', 'cursor'), 'cursor-page-2')

--- a/tap_hubspot/tests/unittests/test_engagements.py
+++ b/tap_hubspot/tests/unittests/test_engagements.py
@@ -83,24 +83,6 @@ class TestSyncEngagements(unittest.TestCase):
     @patch('singer.write_schema')
     @patch('tap_hubspot.request')
     @patch('tap_hubspot.get_start', return_value='2023-01-01T00:00:00.000000Z')
-    def test_modified_after_request_resumes_from_in_flight_cursor_offset(
-        self, mock_get_start, mock_request, mock_write_schema, mock_write_state
-    ):
-        mock_request.return_value = make_response([])
-        in_flight_cursor = "in-flight-cursor-xyz"
-        state = {
-            "bookmarks": {"engagements": {"cursor": "old-cursor", "offset": {"cursor": in_flight_cursor}}}
-        }
-
-        sync_engagements(state, self.make_ctx())
-
-        call_params = mock_request.call_args[0][1]
-        self.assertEqual(call_params['after'], in_flight_cursor)
-
-    @patch('singer.write_state')
-    @patch('singer.write_schema')
-    @patch('tap_hubspot.request')
-    @patch('tap_hubspot.get_start', return_value='2023-01-01T00:00:00.000000Z')
     def test_engagements_page_size_maps_to_delta_limit(
         self, mock_get_start, mock_request, mock_write_schema, mock_write_state
     ):

--- a/tap_hubspot/tests/unittests/test_engagements.py
+++ b/tap_hubspot/tests/unittests/test_engagements.py
@@ -1,0 +1,114 @@
+import json
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+from tap_hubspot import sync_engagements
+
+
+_SCHEMA_PATH = os.path.join(os.path.dirname(__file__), '..', '..', 'schemas', 'engagements.json')
+with open(_SCHEMA_PATH) as _f:
+    ENGAGEMENTS_SCHEMA = json.load(_f)
+
+
+def make_engagement(eid, last_updated_millis):
+    return {
+        "engagement": {
+            "id": eid,
+            "lastUpdated": last_updated_millis,
+            "type": "NOTE"
+        },
+        "associations": {"contactIds": [], "companyIds": [], "dealIds": []},
+        "attachments": [],
+        "metadata": {"body": "test"}
+    }
+
+
+def make_response(results, has_more=False, after=None):
+    resp = MagicMock()
+    body = {"results": results, "hasMore": has_more}
+    if after is not None:
+        body["after"] = after
+    resp.json.return_value = body
+    return resp
+
+
+class TestSyncEngagements(unittest.TestCase):
+    def setUp(self):
+        patcher = patch('tap_hubspot.load_schema', return_value=ENGAGEMENTS_SCHEMA)
+        self.mock_load_schema = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def make_ctx(self):
+        mock_ctx = MagicMock()
+        mock_ctx.get_catalog_from_id.return_value = {
+            "metadata": [],
+            "stream_alias": None
+        }
+        return mock_ctx
+
+    @patch('singer.write_state')
+    @patch('singer.write_schema')
+    @patch('tap_hubspot.request')
+    @patch('tap_hubspot.get_start', return_value='2023-06-15T00:00:00.000000Z')
+    def test_modified_after_request_starts_from_last_updated_bookmark(
+        self, mock_get_start, mock_request, mock_write_schema, mock_write_state
+    ):
+        mock_request.return_value = make_response([])
+        state = {"bookmarks": {"engagements": {"lastUpdated": "2023-06-15T00:00:00.000000Z"}}}
+
+        sync_engagements(state, self.make_ctx())
+
+        call_params = mock_request.call_args[0][1]
+        expected_millis = 1686787200000
+        self.assertEqual(call_params['after'], expected_millis)
+
+    @patch('singer.write_state')
+    @patch('singer.write_schema')
+    @patch('tap_hubspot.request')
+    @patch('tap_hubspot.get_start', return_value='2023-01-01T00:00:00.000000Z')
+    def test_modified_after_request_resumes_from_cursor_bookmark(
+        self, mock_get_start, mock_request, mock_write_schema, mock_write_state
+    ):
+        mock_request.return_value = make_response([])
+        cursor = "opaque-cursor-abc123"
+        state = {"bookmarks": {"engagements": {"cursor": cursor}}}
+
+        sync_engagements(state, self.make_ctx())
+
+        call_params = mock_request.call_args[0][1]
+        self.assertEqual(call_params['after'], cursor)
+
+    @patch('singer.write_state')
+    @patch('singer.write_schema')
+    @patch('tap_hubspot.request')
+    @patch('tap_hubspot.get_start', return_value='2023-01-01T00:00:00.000000Z')
+    def test_modified_after_request_resumes_from_in_flight_cursor_offset(
+        self, mock_get_start, mock_request, mock_write_schema, mock_write_state
+    ):
+        mock_request.return_value = make_response([])
+        in_flight_cursor = "in-flight-cursor-xyz"
+        state = {
+            "bookmarks": {"engagements": {"cursor": "old-cursor", "offset": {"cursor": in_flight_cursor}}}
+        }
+
+        sync_engagements(state, self.make_ctx())
+
+        call_params = mock_request.call_args[0][1]
+        self.assertEqual(call_params['after'], in_flight_cursor)
+
+    @patch('singer.write_state')
+    @patch('singer.write_schema')
+    @patch('tap_hubspot.request')
+    @patch('tap_hubspot.get_start', return_value='2023-01-01T00:00:00.000000Z')
+    def test_engagements_page_size_maps_to_delta_limit(
+        self, mock_get_start, mock_request, mock_write_schema, mock_write_state
+    ):
+        mock_request.return_value = make_response([])
+        state = {"bookmarks": {"engagements": {}}}
+
+        with patch.dict('tap_hubspot.CONFIG', {'engagements_page_size': 50}):
+            sync_engagements(state, self.make_ctx())
+
+        call_params = mock_request.call_args[0][1]
+        self.assertEqual(call_params['limit'], 50)

--- a/tap_hubspot/tests/unittests/test_engagements.py
+++ b/tap_hubspot/tests/unittests/test_engagements.py
@@ -1,7 +1,9 @@
 import json
 import os
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
+
+import singer
 
 from tap_hubspot import sync_engagements
 
@@ -9,19 +11,6 @@ from tap_hubspot import sync_engagements
 _SCHEMA_PATH = os.path.join(os.path.dirname(__file__), '..', '..', 'schemas', 'engagements.json')
 with open(_SCHEMA_PATH) as _f:
     ENGAGEMENTS_SCHEMA = json.load(_f)
-
-
-def make_engagement(eid, last_updated_millis):
-    return {
-        "engagement": {
-            "id": eid,
-            "lastUpdated": last_updated_millis,
-            "type": "NOTE"
-        },
-        "associations": {"contactIds": [], "companyIds": [], "dealIds": []},
-        "attachments": [],
-        "metadata": {"body": "test"}
-    }
 
 
 def make_response(results, has_more=False, after=None):
@@ -94,3 +83,44 @@ class TestSyncEngagements(unittest.TestCase):
 
         call_params = mock_request.call_args[0][1]
         self.assertEqual(call_params['limit'], 50)
+
+    @patch('singer.write_state')
+    @patch('singer.write_schema')
+    @patch('tap_hubspot.request')
+    @patch('tap_hubspot.get_start', return_value='2023-01-01T00:00:00.000000Z')
+    def test_inflight_offset_takes_precedence_over_cursor_bookmark(
+        self, mock_get_start, mock_request, mock_write_schema, mock_write_state
+    ):
+        mock_request.return_value = make_response([])
+        state = {
+            "bookmarks": {"engagements": {
+                "cursor": "old-cursor",
+                "offset": {"after": "inflight-cursor-xyz"},
+            }},
+        }
+
+        sync_engagements(state, self.make_ctx())
+
+        call_params = mock_request.call_args[0][1]
+        self.assertEqual(call_params['after'], "inflight-cursor-xyz")
+
+    @patch('singer.write_state')
+    @patch('singer.write_schema')
+    @patch('tap_hubspot.request')
+    @patch('tap_hubspot.get_start', return_value='2023-01-01T00:00:00.000000Z')
+    def test_offset_persisted_per_page_and_cleared_on_completion(
+        self, mock_get_start, mock_request, mock_write_schema, mock_write_state
+    ):
+        mock_request.side_effect = [
+            make_response([], has_more=True, after="cursor-page-1"),
+            make_response([], has_more=False, after="cursor-page-2"),
+        ]
+        state = {"bookmarks": {"engagements": {}}}
+
+        result = sync_engagements(state, self.make_ctx())
+
+        self.assertNotIn('engagements', result.get('offset', {}))
+        self.assertEqual(
+            singer.get_bookmark(result, 'engagements', 'cursor'),
+            'cursor-page-2'
+        )

--- a/tap_hubspot/tests/unittests/test_engagements.py
+++ b/tap_hubspot/tests/unittests/test_engagements.py
@@ -2,7 +2,7 @@ import copy
 import json
 import os
 import unittest
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 
 import singer
 
@@ -120,7 +120,7 @@ class TestSyncEngagements(unittest.TestCase):
 
         result = sync_engagements(state, self.make_ctx())
 
-        self.assertNotIn('engagements', result.get('offset', {}))
+        self.assertIsNone(singer.get_offset(result, 'engagements'))
         self.assertEqual(
             singer.get_bookmark(result, 'engagements', 'cursor'),
             'cursor-page-2'


### PR DESCRIPTION
*Submitted on behalf of HubSpot Engineering *


# Description of change
Migrate `sync_engagements()` from `GET /engagements/v1/engagements/paged` to the new `GET /engagements/v1/engagements/modified/after` cursor-based endpoint.

The old `/paged` path does full offset scans with client-side `lastUpdated` filtering, generating significant egress ). r

Changes:
- Bootstrap: converts existing `lastUpdated` bookmark to initial `after` timestamp
- Durable state: persists opaque `cursor` bookmark; clears stale `lastUpdated` on completion
- Crash recovery: in-flight `offset.cursor` takes precedence over `cursor` for interrupted runs
- Removed `current_sync_start` 






# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [x] this PR has been written with the help of GitHub Copilot or another generative AI tool
