### PR TITLE
Sync contact lists in desc order of updated_at

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ workflows:
   version: 2
 
   # Fast suite - runs on every commit/PR push
-  commit:
+  commit: &commit_jobs
     jobs:
       - ensure_env:
           context:
@@ -99,8 +99,24 @@ workflows:
             - tier-1-tap-user
           requires:
             - ensure_env
-      # Comprehensive test covers discovery metadata, automatic fields,
-      # sync validation, and bookmark behavior in a single run
+      - integration_test:
+          name: "Pagination Test"
+          context:
+            - circleci-user
+            - tier-1-tap-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_hubspot_pagination.py
+          requires:
+            - ensure_env
+      - integration_test:
+          name: "Bookmarks Test CRUD"
+          context:
+            - circleci-user
+            - tier-1-tap-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_hubspot_bookmarks.py
+          requires:
+            - ensure_env
       - integration_test:
           name: "Comprehensive Test"
           context:
@@ -128,26 +144,15 @@ workflows:
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_hubspot_interrupted_sync.py
           requires:
             - ensure_env
-      - build:
+      - integration_test:
+          name: "Discovery Test"
           context:
             - circleci-user
             - tier-1-tap-user
+          test_command: |-
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_hubspot_discovery.py
           requires:
-            - run_pylint_and_unittests
-            - "Comprehensive Test"
-            - "Child Streams Test"
-            - "Interrupted State Test"
-
-  # Full suite - runs only on master merges
-  master: &full_suite
-    jobs:
-      - ensure_env:
-          context:
-            - circleci-user
-            - tier-1-tap-user
-          filters:
-            branches:
-              only: master
+            - ensure_env
       - integration_test:
           name: "Start Date Test"
           context:
@@ -157,6 +162,7 @@ workflows:
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_hubspot_start_date.py
           requires:
             - ensure_env
+            - "Pagination Test"
       - integration_test:
           name: "All Fields Test"
           context:
@@ -166,24 +172,30 @@ workflows:
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_hubspot_all_fields.py
           requires:
             - ensure_env
+            - "Bookmarks Test CRUD"
+            - "Pagination Test"
       - integration_test:
-          name: "Pagination Test"
+          name: "Automatic Fields Test"
           context:
             - circleci-user
             - tier-1-tap-user
           test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_hubspot_pagination.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_hubspot_automatic_fields.py
           requires:
             - ensure_env
+            - "Bookmarks Test CRUD"
+            - "Pagination Test"
       - integration_test:
-          name: "Bookmarks Test CRUD"
+          name: "New All Fields Test"
           context:
             - circleci-user
             - tier-1-tap-user
           test_command: |-
-            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_hubspot_bookmarks.py
+            run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_hubspot_newfw_all_fields.py
           requires:
             - ensure_env
+            - "Bookmarks Test CRUD"
+            - "Pagination Test"
       - integration_test:
           name: "Bookmarks Test Static Data"
           context:
@@ -208,14 +220,11 @@ workflows:
             - circleci-user
             - tier-1-tap-user
           requires:
-            - "Start Date Test"
-            - "All Fields Test"
-            - "Pagination Test"
-            - "Interrupted State with Offset Test"
+            - run_pylint_and_unittests
 
   # Full suite on a daily schedule to catch API changes
   build_daily:
-    <<: *full_suite
+    <<: *commit_jobs
     triggers:
       - schedule:
           cron: "0 1 * * *"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,7 @@ workflows:
             run-test --tap=${CIRCLE_PROJECT_REPONAME} tests/test_hubspot_pagination.py
           requires:
             - ensure_env
+            - "Bookmarks Test CRUD"
       - integration_test:
           name: "Bookmarks Test CRUD"
           context:
@@ -184,6 +185,7 @@ workflows:
           requires:
             - ensure_env
             - "Bookmarks Test CRUD"
+            - "Start Date Test"
             - "Pagination Test"
       - integration_test:
           name: "New All Fields Test"
@@ -195,6 +197,7 @@ workflows:
           requires:
             - ensure_env
             - "Bookmarks Test CRUD"
+            - "Start Date Test"
             - "Pagination Test"
       - integration_test:
           name: "Bookmarks Test Static Data"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.3.1
+  * Sync contact_lists in reverse order. [#304](https://github.com/singer-io/tap-hubspot/pull/304)
+
 ## 4.3.0
   * Always write bookmarks for form_submissions and list_memberships streams, even when there are no records. [#292](https://github.com/singer-io/tap-hubspot/pull/292)
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ This tap:
   - [Contacts](https://developers.hubspot.com/docs/api-reference/crm-contacts-v3/basic/get-crm-v3-objects-contacts)
   - [Contact Lists](https://developers.hubspot.com/docs/api-reference/crm-lists-v3/lists/post-crm-v3-lists-search)
   - [List Memberships](https://developers.hubspot.com/docs/api-reference/crm-lists-v3/memberships/get-crm-v3-lists-listId-memberships)
+    - **Limitation**: HubSpot's `/crm/v3/lists/search` [endpoint](https://developers.hubspot.com/docs/api-reference/latest/crm/lists/search/search-lists) enforces a hard [10,000 record offset ceiling](https://developers.hubspot.com/docs/api-reference/latest/crm/search-the-crm#:~:text=The%20search%20endpoints%20are%20limited%20to%2010%2C000%20total%20results%20for%20any%20given%20query.%20Attempting%20to%20page%20beyond%2010%2C000%20will%20result%20in%20a%20400%20error.). It does not return records beyond that. There is no other endpoint available that can replace it.
+    - To maximize coverage:
+      - Historic sync (no bookmark): Fetch in BOTH ascending and descending order of `HS_UPDATED_AT`. This gives up to ~20K unique records. After the ascending pass, `start` is updated to `max_bk_value` so the descending pass only emits records newer than what was already seen, effectively deduplicating (with at most 1 record overlap at the boundary).
+      - From next sync onwards: Fetch only in descending order (`-HS_UPDATED_AT`). This retrieves the latest 10K updated records.
+
   - [Deals](http://developers.hubspot.com/docs/methods/deals/get_deals_modified)
   - [Deal Pipelines](https://developers.hubspot.com/docs/methods/deal-pipelines/get-all-deal-pipelines)
   - [Email Events](http://developers.hubspot.com/docs/methods/email/get_events)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-hubspot',
-      version='4.3.0',
+      version='4.3.1',
       description='Singer.io tap for extracting data from the HubSpot API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -914,7 +914,7 @@ def sync_contact_lists(STATE, ctx):
     bookmark_key = 'updatedAt'
     singer.write_schema("contact_lists", schema, ["listId"], [bookmark_key], catalog.get('stream_alias'))
 
-    start = "2026-05-05T00:00:00Z"
+    start = get_start(STATE, "contact_lists", bookmark_key)
     max_bk_value = start
 
     LOGGER.info("sync_contact_lists from %s", start)

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -948,12 +948,13 @@ def sync_contact_lists(STATE, ctx):
     else:
         sort_options = ["-HS_UPDATED_AT"]
 
+    # To handle records updated between start of the table sync and the end,
+    # store the current sync start in the state and not move the bookmark past this value.
+    sync_start_time = utils.now()
+
     for _option in sort_options:
         body = {'count': 250, 'sort': _option}
         with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
-            # To handle records updated between start of the table sync and the end,
-            # store the current sync start in the state and not move the bookmark past this value.
-            sync_start_time = utils.now()
             has_more = True
             while has_more:
                 data = post_search_endpoint(url, body).json()

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -931,35 +931,52 @@ def sync_contact_lists(STATE, ctx):
         LOGGER.info("sync list_memberships from %s", fs_start)
 
     url = get_url("contact_lists")
-    body = {'count': 250, "sort": "-HS_UPDATED_AT"}
-    first_record_bookmark = None
-    with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
-        # To handle records updated between start of the table sync and the end,
-        # store the current sync start in the state and not move the bookmark past this value.
-        sync_start_time = utils.now()
-        has_more = True
-        has_synced_data = False
-        while has_more:
-            data = post_search_endpoint(url, body).json()
-            for row in data["lists"]:
-                has_synced_data = True
-                record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
-                if record[bookmark_key] >= start:
-                    singer.write_record("contact_lists", record, catalog.get('stream_alias'), time_extracted=utils.now())
-                if first_record_bookmark is None:
-                    first_record_bookmark = record[bookmark_key]
+    has_synced_data = False
 
-                if "list_memberships" in ctx.selected_stream_ids:
-                    STATE, fs_max_bk_value = sync_list_memberships(row['listId'], STATE, fs_schema, fs_catalog, fs_bookmark_key, fs_start, fs_max_bk_value)
+    # HubSpot's /crm/v3/lists/search endpoint enforces a hard 10,000 record offset ceiling.
+    # To maximize coverage:
+    #   - Historic sync (no bookmark): Fetch in BOTH ascending and descending order of HS_UPDATED_AT.
+    #     This gives up to ~20K unique records. After the ascending pass, `start` is updated to
+    #     `max_bk_value` so the descending pass only emits records newer than what was already seen,
+    #     effectively deduplicating (with at most 1 record overlap at the boundary).
+    #   - Incremental sync (bookmark present): Fetch only in descending order (-HS_UPDATED_AT).
+    #     This retrieves the latest 10K updated records. Records older than the bookmark are
+    #     still iterated (for list_memberships) but not written to contact_lists output.
+    # Limitation: If total lists exceed ~20K, records in the "middle" may be missed on historic sync.
+    if not singer.get_bookmark(STATE, "contact_lists", bookmark_key):
+        sort_options = ["HS_UPDATED_AT", "-HS_UPDATED_AT"]
+    else:
+        sort_options = ["-HS_UPDATED_AT"]
 
-            has_more = data.get('hasMore')
-            body["offset"] = data["offset"]
+    for _option in sort_options:
+        body = {'count': 250, 'sort': _option}
+        with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
+            # To handle records updated between start of the table sync and the end,
+            # store the current sync start in the state and not move the bookmark past this value.
+            sync_start_time = utils.now()
+            has_more = True
+            while has_more:
+                data = post_search_endpoint(url, body).json()
+                for row in data["lists"]:
+                    has_synced_data = True
+                    record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
+                    if record[bookmark_key] >= start:
+                        singer.write_record("contact_lists", record, catalog.get('stream_alias'), time_extracted=utils.now())
+                    if record[bookmark_key] >= max_bk_value:
+                        max_bk_value = record[bookmark_key]
 
-    if first_record_bookmark is None:
-        first_record_bookmark = max_bk_value
+                    if "list_memberships" in ctx.selected_stream_ids:
+                        STATE, fs_max_bk_value = sync_list_memberships(row['listId'], STATE, fs_schema, fs_catalog, fs_bookmark_key, fs_start, fs_max_bk_value)
+
+                has_more = data.get('hasMore')
+                body["offset"] = data["offset"]
+
+        # Update `start` so that the next pass (descending) only writes records
+        # newer than what was already emitted in the ascending pass.
+        start = max_bk_value
 
     # Don't bookmark past the start of this sync to account for updated records during the sync.
-    new_bookmark = min(utils.strptime_to_utc(first_record_bookmark), sync_start_time)
+    new_bookmark = min(utils.strptime_to_utc(max_bk_value), sync_start_time)
     # Child stream list_memberships is INCREMENTAL and needs a bookmark even if no records are extracted
     if not has_synced_data and "list_memberships" in ctx.selected_stream_ids:
         STATE = singer.write_bookmark(STATE, 'list_memberships', fs_bookmark_key, utils.strftime(new_bookmark))

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -914,7 +914,7 @@ def sync_contact_lists(STATE, ctx):
     bookmark_key = 'updatedAt'
     singer.write_schema("contact_lists", schema, ["listId"], [bookmark_key], catalog.get('stream_alias'))
 
-    start = get_start(STATE, "contact_lists", bookmark_key)
+    start = "2026-05-05T00:00:00Z"
     max_bk_value = start
 
     LOGGER.info("sync_contact_lists from %s", start)
@@ -931,7 +931,8 @@ def sync_contact_lists(STATE, ctx):
         LOGGER.info("sync list_memberships from %s", fs_start)
 
     url = get_url("contact_lists")
-    body = {'count': 250}
+    body = {'count': 250, "sort": "-HS_UPDATED_AT"}
+    first_record_bookmark = None
     with Transformer(UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as bumble_bee:
         # To handle records updated between start of the table sync and the end,
         # store the current sync start in the state and not move the bookmark past this value.
@@ -945,8 +946,8 @@ def sync_contact_lists(STATE, ctx):
                 record = bumble_bee.transform(lift_properties_and_versions(row), schema, mdata)
                 if record[bookmark_key] >= start:
                     singer.write_record("contact_lists", record, catalog.get('stream_alias'), time_extracted=utils.now())
-                if record[bookmark_key] >= max_bk_value:
-                    max_bk_value = record[bookmark_key]
+                if first_record_bookmark is None:
+                    first_record_bookmark = record[bookmark_key]
 
                 if "list_memberships" in ctx.selected_stream_ids:
                     STATE, fs_max_bk_value = sync_list_memberships(row['listId'], STATE, fs_schema, fs_catalog, fs_bookmark_key, fs_start, fs_max_bk_value)
@@ -954,8 +955,11 @@ def sync_contact_lists(STATE, ctx):
             has_more = data.get('hasMore')
             body["offset"] = data["offset"]
 
+    if first_record_bookmark is None:
+        first_record_bookmark = max_bk_value
+
     # Don't bookmark past the start of this sync to account for updated records during the sync.
-    new_bookmark = min(utils.strptime_to_utc(max_bk_value), sync_start_time)
+    new_bookmark = min(utils.strptime_to_utc(first_record_bookmark), sync_start_time)
     # Child stream list_memberships is INCREMENTAL and needs a bookmark even if no records are extracted
     if not has_synced_data and "list_memberships" in ctx.selected_stream_ids:
         STATE = singer.write_bookmark(STATE, 'list_memberships', fs_bookmark_key, utils.strftime(new_bookmark))

--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -919,6 +919,7 @@ def sync_contact_lists(STATE, ctx):
 
     LOGGER.info("sync_contact_lists from %s", start)
 
+    fs_max_bk_value = None
     if "list_memberships" in ctx.selected_stream_ids:
         fs_schema = load_schema("list_memberships")
         fs_catalog = ctx.get_catalog_from_id("list_memberships")
@@ -975,6 +976,7 @@ def sync_contact_lists(STATE, ctx):
         # Update `start` so that the next pass (descending) only writes records
         # newer than what was already emitted in the ascending pass.
         start = max_bk_value
+        fs_start = fs_max_bk_value
 
     # Don't bookmark past the start of this sync to account for updated records during the sync.
     new_bookmark = min(utils.strptime_to_utc(max_bk_value), sync_start_time)

--- a/tap_hubspot/tests/unittests/test_contact_lists.py
+++ b/tap_hubspot/tests/unittests/test_contact_lists.py
@@ -1,0 +1,1179 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from datetime import datetime, timezone
+
+import singer
+import tap_hubspot
+from tap_hubspot import sync_contact_lists
+
+
+class MockResponse:
+    def __init__(self, json_data):
+        self.json_data = json_data
+        self.status_code = 200
+
+    def json(self):
+        return self.json_data
+
+
+class MockContext:
+    def __init__(self, selected_stream_ids=None):
+        self.selected_stream_ids = selected_stream_ids or ["contact_lists"]
+
+    def get_catalog_from_id(self, stream_name):
+        return {
+            "stream": "contact_lists",
+            "tap_stream_id": "contact_lists",
+            "stream_alias": None,
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "listId": {"type": ["null", "string"]},
+                    "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                    "name": {"type": ["null", "string"]},
+                    "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                    "processingType": {"type": ["null", "string"]},
+                }
+            },
+            "metadata": [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "table-key-properties": ["listId"],
+                        "forced-replication-method": "INCREMENTAL",
+                        "valid-replication-keys": ["updatedAt"],
+                        "selected": True
+                    }
+                },
+                {
+                    "breadcrumb": ["properties", "listId"],
+                    "metadata": {"inclusion": "automatic"}
+                },
+                {
+                    "breadcrumb": ["properties", "updatedAt"],
+                    "metadata": {"inclusion": "automatic"}
+                },
+                {
+                    "breadcrumb": ["properties", "name"],
+                    "metadata": {"inclusion": "available", "selected": True}
+                },
+                {
+                    "breadcrumb": ["properties", "createdAt"],
+                    "metadata": {"inclusion": "available", "selected": True}
+                },
+                {
+                    "breadcrumb": ["properties", "processingType"],
+                    "metadata": {"inclusion": "available", "selected": True}
+                },
+            ]
+        }
+
+
+def make_list_record(list_id, updated_at, name="Test List"):
+    """Helper to create a mock HubSpot list record."""
+    return {
+        "listId": str(list_id),
+        "updatedAt": updated_at,
+        "name": name,
+        "createdAt": "2024-01-01T00:00:00Z",
+        "processingType": "MANUAL",
+    }
+
+
+def make_api_response(lists, has_more=False, offset=0):
+    """Helper to create a mock API response."""
+    return {
+        "lists": lists,
+        "hasMore": has_more,
+        "offset": offset,
+        "total": len(lists),
+    }
+
+
+class TestSyncContactListsHistoricSync(unittest.TestCase):
+    """
+    Tests for historic sync (no bookmark present in state).
+    Should use both ascending and descending sort orders.
+    """
+
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_historic_sync_uses_both_sort_orders(self, mock_now, mock_load_schema, mock_post):
+        """
+        When no bookmark exists, sync should iterate in ascending order first,
+        then descending order to maximize coverage (up to ~20K records).
+        """
+        mock_now.return_value = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_load_schema.return_value = {
+            "type": "object",
+            "properties": {
+                "listId": {"type": ["null", "string"]},
+                "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                "name": {"type": ["null", "string"]},
+                "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                "processingType": {"type": ["null", "string"]},
+            }
+        }
+
+        asc_records = [
+            make_list_record(1, "2024-01-01T00:00:00Z"),
+            make_list_record(2, "2024-01-02T00:00:00Z"),
+            make_list_record(3, "2024-01-03T00:00:00Z"),
+        ]
+        desc_records = [
+            make_list_record(6, "2024-05-01T00:00:00Z"),
+            make_list_record(5, "2024-04-01T00:00:00Z"),
+            make_list_record(4, "2024-03-01T00:00:00Z"),
+        ]
+
+        mock_post.side_effect = [
+            MockResponse(make_api_response(asc_records, has_more=False)),
+            MockResponse(make_api_response(desc_records, has_more=False)),
+        ]
+
+        STATE = {"currently_syncing": "contact_lists", "bookmarks": {}}
+        ctx = MockContext()
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        written_records = []
+        original_write_record = singer.write_record
+        singer.write_record = lambda *args, **kwargs: written_records.append(args)
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+        original_write_bookmark = singer.write_bookmark
+        singer.write_bookmark = lambda state, stream, key, val: singer.bookmarks.write_bookmark(state, stream, key, val)
+
+        try:
+            sync_contact_lists(STATE, ctx)
+
+            # Verify both sort orders were used
+            self.assertEqual(mock_post.call_count, 2)
+
+            # First call should be ascending
+            first_call_body = mock_post.call_args_list[0][0][1]
+            self.assertEqual(first_call_body['sort'], 'HS_UPDATED_AT')
+
+            # Second call should be descending
+            second_call_body = mock_post.call_args_list[1][0][1]
+            self.assertEqual(second_call_body['sort'], '-HS_UPDATED_AT')
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+            singer.write_bookmark = original_write_bookmark
+
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_historic_sync_deduplication_via_start_update(self, mock_now, mock_load_schema, mock_post):
+        """
+        After the ascending pass, `start` is updated to `max_bk_value`.
+        The descending pass should only emit records with updatedAt >= new start,
+        preventing duplicates (except at the boundary).
+        """
+        mock_now.return_value = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_load_schema.return_value = {
+            "type": "object",
+            "properties": {
+                "listId": {"type": ["null", "string"]},
+                "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                "name": {"type": ["null", "string"]},
+                "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                "processingType": {"type": ["null", "string"]},
+            }
+        }
+
+        # Ascending: records from Jan to Mar (max = Mar 3)
+        asc_records = [
+            make_list_record(1, "2024-01-01T00:00:00Z"),
+            make_list_record(2, "2024-02-01T00:00:00Z"),
+            make_list_record(3, "2024-03-03T00:00:00Z"),
+        ]
+        # Descending: records from May to Feb (some overlap with ascending)
+        desc_records = [
+            make_list_record(6, "2024-05-01T00:00:00Z"),
+            make_list_record(5, "2024-04-01T00:00:00Z"),
+            make_list_record(3, "2024-03-03T00:00:00Z"),  # boundary record (same as asc max)
+            make_list_record(2, "2024-02-01T00:00:00Z"),  # already seen, older than start
+        ]
+
+        mock_post.side_effect = [
+            MockResponse(make_api_response(asc_records, has_more=False)),
+            MockResponse(make_api_response(desc_records, has_more=False)),
+        ]
+
+        STATE = {"currently_syncing": "contact_lists", "bookmarks": {}}
+        ctx = MockContext()
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        written_records = []
+        original_write_record = singer.write_record
+        singer.write_record = lambda stream, record, *args, **kwargs: written_records.append(record)
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+        original_write_bookmark = singer.write_bookmark
+        singer.write_bookmark = lambda state, stream, key, val: singer.bookmarks.write_bookmark(state, stream, key, val)
+
+        try:
+            sync_contact_lists(STATE, ctx)
+
+            # Ascending pass writes all 3 records (all >= start_date)
+            # Descending pass: start is updated to "2024-03-03T00:00:00Z"
+            # - list 6 (May): >= start -> written
+            # - list 5 (Apr): >= start -> written
+            # - list 3 (Mar 3): >= start -> written (boundary duplicate, 1 overlap acceptable)
+            # - list 2 (Feb): < start -> NOT written
+            #
+            # Total: 3 (asc) + 3 (desc) = 6 records written (with 1 acceptable duplicate of list 3)
+            written_list_ids = [r.get('listId') for r in written_records]
+            self.assertEqual(len(written_records), 6)
+
+            # list 2 should only appear once (from ascending pass)
+            self.assertEqual(written_list_ids.count("2"), 1)
+
+            # list 3 appears twice (boundary overlap) - acceptable
+            self.assertEqual(written_list_ids.count("3"), 2)
+
+            # list 6 and 5 only from descending
+            self.assertIn("6", written_list_ids)
+            self.assertIn("5", written_list_ids)
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+            singer.write_bookmark = original_write_bookmark
+
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_historic_sync_bookmark_set_to_max_value(self, mock_now, mock_load_schema, mock_post):
+        """
+        After historic sync, bookmark should be set to the maximum updatedAt value
+        seen across both passes (capped by sync_start_time).
+        """
+        mock_now.return_value = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_load_schema.return_value = {
+            "type": "object",
+            "properties": {
+                "listId": {"type": ["null", "string"]},
+                "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                "name": {"type": ["null", "string"]},
+                "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                "processingType": {"type": ["null", "string"]},
+            }
+        }
+
+        asc_records = [make_list_record(1, "2024-01-01T00:00:00Z")]
+        desc_records = [make_list_record(2, "2024-05-15T00:00:00Z")]
+
+        mock_post.side_effect = [
+            MockResponse(make_api_response(asc_records, has_more=False)),
+            MockResponse(make_api_response(desc_records, has_more=False)),
+        ]
+
+        STATE = {"currently_syncing": "contact_lists", "bookmarks": {}}
+        ctx = MockContext()
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        original_write_record = singer.write_record
+        singer.write_record = MagicMock()
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+
+        try:
+            result_state = sync_contact_lists(STATE, ctx)
+
+            # Bookmark should be max(all records seen) = 2024-05-15, capped by sync_start_time (June 1)
+            bookmark = singer.get_bookmark(result_state, 'contact_lists', 'updatedAt')
+            self.assertEqual(bookmark, "2024-05-15T00:00:00.000000Z")
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_historic_sync_bookmark_capped_by_sync_start_time(self, mock_now, mock_load_schema, mock_post):
+        """
+        If max_bk_value is in the future (unlikely but defensive), bookmark should
+        be capped at sync_start_time.
+        """
+        mock_now.return_value = datetime(2024, 3, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_load_schema.return_value = {
+            "type": "object",
+            "properties": {
+                "listId": {"type": ["null", "string"]},
+                "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                "name": {"type": ["null", "string"]},
+                "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                "processingType": {"type": ["null", "string"]},
+            }
+        }
+
+        asc_records = [make_list_record(1, "2024-01-01T00:00:00Z")]
+        desc_records = [make_list_record(2, "2024-05-01T00:00:00Z")]
+
+        mock_post.side_effect = [
+            MockResponse(make_api_response(asc_records, has_more=False)),
+            MockResponse(make_api_response(desc_records, has_more=False)),
+        ]
+
+        STATE = {"currently_syncing": "contact_lists", "bookmarks": {}}
+        ctx = MockContext()
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        original_write_record = singer.write_record
+        singer.write_record = MagicMock()
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+
+        try:
+            result_state = sync_contact_lists(STATE, ctx)
+
+            # Bookmark capped at sync_start_time (March 1)
+            bookmark = singer.get_bookmark(result_state, 'contact_lists', 'updatedAt')
+            self.assertEqual(bookmark, "2024-03-01T00:00:00.000000Z")
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+
+
+class TestSyncContactListsIncrementalSync(unittest.TestCase):
+    """
+    Tests for incremental sync (bookmark present in state).
+    Should use only descending sort order.
+    """
+
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_incremental_sync_uses_only_desc_order(self, mock_now, mock_load_schema, mock_post):
+        """
+        When bookmark exists, sync should only use descending sort order.
+        """
+        mock_now.return_value = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_load_schema.return_value = {
+            "type": "object",
+            "properties": {
+                "listId": {"type": ["null", "string"]},
+                "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                "name": {"type": ["null", "string"]},
+                "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                "processingType": {"type": ["null", "string"]},
+            }
+        }
+
+        desc_records = [
+            make_list_record(3, "2024-05-01T00:00:00Z"),
+            make_list_record(2, "2024-04-01T00:00:00Z"),
+            make_list_record(1, "2024-03-01T00:00:00Z"),
+        ]
+
+        mock_post.return_value = MockResponse(make_api_response(desc_records, has_more=False))
+
+        STATE = {
+            "currently_syncing": "contact_lists",
+            "bookmarks": {"contact_lists": {"updatedAt": "2024-02-01T00:00:00.000000Z"}}
+        }
+        ctx = MockContext()
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        original_write_record = singer.write_record
+        singer.write_record = MagicMock()
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+        original_write_bookmark = singer.write_bookmark
+        singer.write_bookmark = lambda state, stream, key, val: singer.bookmarks.write_bookmark(state, stream, key, val)
+
+        try:
+            sync_contact_lists(STATE, ctx)
+
+            # Only one API call (descending only)
+            self.assertEqual(mock_post.call_count, 1)
+            call_body = mock_post.call_args_list[0][0][1]
+            self.assertEqual(call_body['sort'], '-HS_UPDATED_AT')
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+            singer.write_bookmark = original_write_bookmark
+
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_incremental_sync_only_writes_records_gte_bookmark(self, mock_now, mock_load_schema, mock_post):
+        """
+        In incremental sync, only records with updatedAt >= bookmark should be written.
+        Records older than bookmark are still iterated but not written.
+        """
+        mock_now.return_value = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_load_schema.return_value = {
+            "type": "object",
+            "properties": {
+                "listId": {"type": ["null", "string"]},
+                "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                "name": {"type": ["null", "string"]},
+                "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                "processingType": {"type": ["null", "string"]},
+            }
+        }
+
+        desc_records = [
+            make_list_record(3, "2024-05-01T00:00:00Z"),  # newer than bookmark
+            make_list_record(2, "2024-04-01T00:00:00Z"),  # newer than bookmark
+            make_list_record(1, "2024-01-01T00:00:00Z"),  # older than bookmark
+        ]
+
+        mock_post.return_value = MockResponse(make_api_response(desc_records, has_more=False))
+
+        STATE = {
+            "currently_syncing": "contact_lists",
+            "bookmarks": {"contact_lists": {"updatedAt": "2024-03-01T00:00:00.000000Z"}}
+        }
+        ctx = MockContext()
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        written_records = []
+        original_write_record = singer.write_record
+        singer.write_record = lambda stream, record, *args, **kwargs: written_records.append(record)
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+        original_write_bookmark = singer.write_bookmark
+        singer.write_bookmark = lambda state, stream, key, val: singer.bookmarks.write_bookmark(state, stream, key, val)
+
+        try:
+            sync_contact_lists(STATE, ctx)
+
+            # Only 2 records should be written (list 3 and list 2)
+            self.assertEqual(len(written_records), 2)
+            written_ids = [r['listId'] for r in written_records]
+            self.assertIn("3", written_ids)
+            self.assertIn("2", written_ids)
+            self.assertNotIn("1", written_ids)
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+            singer.write_bookmark = original_write_bookmark
+
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_incremental_sync_iterates_all_pages(self, mock_now, mock_load_schema, mock_post):
+        """
+        Incremental sync should iterate through all pages (no early stopping),
+        even when records are older than bookmark.
+        """
+        mock_now.return_value = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_load_schema.return_value = {
+            "type": "object",
+            "properties": {
+                "listId": {"type": ["null", "string"]},
+                "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                "name": {"type": ["null", "string"]},
+                "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                "processingType": {"type": ["null", "string"]},
+            }
+        }
+
+        page1 = [make_list_record(3, "2024-05-01T00:00:00Z")]
+        page2 = [make_list_record(1, "2024-01-01T00:00:00Z")]
+
+        responses = [
+            MockResponse(make_api_response(page1, has_more=True, offset=250)),
+            MockResponse(make_api_response(page2, has_more=False)),
+        ]
+        captured_bodies = []
+
+        def capture_post(url, body):
+            captured_bodies.append(dict(body))
+            return responses.pop(0)
+
+        mock_post.side_effect = capture_post
+
+        STATE = {
+            "currently_syncing": "contact_lists",
+            "bookmarks": {"contact_lists": {"updatedAt": "2024-03-01T00:00:00.000000Z"}}
+        }
+        ctx = MockContext()
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        original_write_record = singer.write_record
+        singer.write_record = MagicMock()
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+        original_write_bookmark = singer.write_bookmark
+        singer.write_bookmark = lambda state, stream, key, val: singer.bookmarks.write_bookmark(state, stream, key, val)
+
+        try:
+            sync_contact_lists(STATE, ctx)
+
+            # Both pages should be fetched (no early stopping)
+            self.assertEqual(mock_post.call_count, 2)
+
+            # Second call should include offset from first response
+            self.assertEqual(captured_bodies[1]['offset'], 250)
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+            singer.write_bookmark = original_write_bookmark
+
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_incremental_sync_bookmark_advances_to_max(self, mock_now, mock_load_schema, mock_post):
+        """
+        After incremental sync, bookmark should advance to the max updatedAt seen.
+        """
+        mock_now.return_value = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_load_schema.return_value = {
+            "type": "object",
+            "properties": {
+                "listId": {"type": ["null", "string"]},
+                "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                "name": {"type": ["null", "string"]},
+                "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                "processingType": {"type": ["null", "string"]},
+            }
+        }
+
+        desc_records = [
+            make_list_record(2, "2024-05-20T00:00:00Z"),
+            make_list_record(1, "2024-05-10T00:00:00Z"),
+        ]
+
+        mock_post.return_value = MockResponse(make_api_response(desc_records, has_more=False))
+
+        STATE = {
+            "currently_syncing": "contact_lists",
+            "bookmarks": {"contact_lists": {"updatedAt": "2024-04-01T00:00:00.000000Z"}}
+        }
+        ctx = MockContext()
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        original_write_record = singer.write_record
+        singer.write_record = MagicMock()
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+
+        try:
+            result_state = sync_contact_lists(STATE, ctx)
+
+            bookmark = singer.get_bookmark(result_state, 'contact_lists', 'updatedAt')
+            self.assertEqual(bookmark, "2024-05-20T00:00:00.000000Z")
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+
+
+class TestSyncContactListsPagination(unittest.TestCase):
+    """
+    Tests for pagination behavior.
+    """
+
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_pagination_follows_hasMore_and_offset(self, mock_now, mock_load_schema, mock_post):
+        """
+        Sync should continue paginating while hasMore is True, using the offset
+        from each response.
+        """
+        mock_now.return_value = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_load_schema.return_value = {
+            "type": "object",
+            "properties": {
+                "listId": {"type": ["null", "string"]},
+                "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                "name": {"type": ["null", "string"]},
+                "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                "processingType": {"type": ["null", "string"]},
+            }
+        }
+
+        page1 = [make_list_record(1, "2024-05-01T00:00:00Z")]
+        page2 = [make_list_record(2, "2024-05-02T00:00:00Z")]
+        page3 = [make_list_record(3, "2024-05-03T00:00:00Z")]
+
+        responses = [
+            MockResponse(make_api_response(page1, has_more=True, offset=250)),
+            MockResponse(make_api_response(page2, has_more=True, offset=500)),
+            MockResponse(make_api_response(page3, has_more=False, offset=750)),
+        ]
+        captured_bodies = []
+
+        def capture_post(url, body):
+            captured_bodies.append(dict(body))
+            return responses.pop(0)
+
+        mock_post.side_effect = capture_post
+
+        STATE = {
+            "currently_syncing": "contact_lists",
+            "bookmarks": {"contact_lists": {"updatedAt": "2024-01-01T00:00:00.000000Z"}}
+        }
+        ctx = MockContext()
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        original_write_record = singer.write_record
+        singer.write_record = MagicMock()
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+        original_write_bookmark = singer.write_bookmark
+        singer.write_bookmark = lambda state, stream, key, val: singer.bookmarks.write_bookmark(state, stream, key, val)
+
+        try:
+            sync_contact_lists(STATE, ctx)
+
+            # 3 pages fetched
+            self.assertEqual(mock_post.call_count, 3)
+
+            # Verify offsets were passed correctly
+            self.assertEqual(captured_bodies[1]['offset'], 250)
+            self.assertEqual(captured_bodies[2]['offset'], 500)
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+            singer.write_bookmark = original_write_bookmark
+
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_historic_sync_pagination_across_both_passes(self, mock_now, mock_load_schema, mock_post):
+        """
+        Historic sync should paginate fully through both ascending and descending passes.
+        Each pass resets offset independently.
+        """
+        mock_now.return_value = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_load_schema.return_value = {
+            "type": "object",
+            "properties": {
+                "listId": {"type": ["null", "string"]},
+                "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                "name": {"type": ["null", "string"]},
+                "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                "processingType": {"type": ["null", "string"]},
+            }
+        }
+
+        asc_page1 = [make_list_record(1, "2024-01-01T00:00:00Z")]
+        asc_page2 = [make_list_record(2, "2024-02-01T00:00:00Z")]
+        desc_page1 = [make_list_record(4, "2024-05-01T00:00:00Z")]
+        desc_page2 = [make_list_record(3, "2024-03-01T00:00:00Z")]
+
+        mock_post.side_effect = [
+            MockResponse(make_api_response(asc_page1, has_more=True, offset=250)),
+            MockResponse(make_api_response(asc_page2, has_more=False, offset=500)),
+            MockResponse(make_api_response(desc_page1, has_more=True, offset=250)),
+            MockResponse(make_api_response(desc_page2, has_more=False, offset=500)),
+        ]
+
+        STATE = {"currently_syncing": "contact_lists", "bookmarks": {}}
+        ctx = MockContext()
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        original_write_record = singer.write_record
+        singer.write_record = MagicMock()
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+        original_write_bookmark = singer.write_bookmark
+        singer.write_bookmark = lambda state, stream, key, val: singer.bookmarks.write_bookmark(state, stream, key, val)
+
+        try:
+            sync_contact_lists(STATE, ctx)
+
+            # 4 total API calls (2 ascending + 2 descending)
+            self.assertEqual(mock_post.call_count, 4)
+
+            # Verify ascending pass sort
+            self.assertEqual(mock_post.call_args_list[0][0][1]['sort'], 'HS_UPDATED_AT')
+            self.assertEqual(mock_post.call_args_list[1][0][1]['sort'], 'HS_UPDATED_AT')
+
+            # Verify descending pass sort
+            self.assertEqual(mock_post.call_args_list[2][0][1]['sort'], '-HS_UPDATED_AT')
+            self.assertEqual(mock_post.call_args_list[3][0][1]['sort'], '-HS_UPDATED_AT')
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+            singer.write_bookmark = original_write_bookmark
+
+
+class TestSyncContactListsEmptyResponses(unittest.TestCase):
+    """
+    Tests for edge cases with empty or no data.
+    """
+
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_empty_response_no_records(self, mock_now, mock_load_schema, mock_post):
+        """
+        When API returns no lists, bookmark should still be written using start_date.
+        """
+        mock_now.return_value = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_load_schema.return_value = {
+            "type": "object",
+            "properties": {
+                "listId": {"type": ["null", "string"]},
+                "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                "name": {"type": ["null", "string"]},
+                "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                "processingType": {"type": ["null", "string"]},
+            }
+        }
+
+        mock_post.return_value = MockResponse(make_api_response([], has_more=False))
+
+        STATE = {"currently_syncing": "contact_lists", "bookmarks": {}}
+        ctx = MockContext()
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        original_write_record = singer.write_record
+        singer.write_record = MagicMock()
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+
+        try:
+            result_state = sync_contact_lists(STATE, ctx)
+
+            # Bookmark should still be written (using start_date as max_bk_value)
+            bookmark = singer.get_bookmark(result_state, 'contact_lists', 'updatedAt')
+            self.assertIsNotNone(bookmark)
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_no_data_synced_list_memberships_bookmark_written(self, mock_now, mock_load_schema, mock_post):
+        """
+        When no data is synced and list_memberships is selected,
+        list_memberships bookmark should still be written.
+        """
+        mock_now.return_value = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        def schema_side_effect(name):
+            return {
+                "type": "object",
+                "properties": {
+                    "listId": {"type": ["null", "string"]},
+                    "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                    "name": {"type": ["null", "string"]},
+                    "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                    "processingType": {"type": ["null", "string"]},
+                    "recordId": {"type": ["null", "string"]},
+                    "membershipTimestamp": {"type": ["null", "string"], "format": "date-time"},
+                }
+            }
+
+        mock_load_schema.side_effect = schema_side_effect
+        mock_post.return_value = MockResponse(make_api_response([], has_more=False))
+
+        STATE = {"currently_syncing": "contact_lists", "bookmarks": {}}
+        ctx = MockContext(selected_stream_ids=["contact_lists", "list_memberships"])
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        original_write_record = singer.write_record
+        singer.write_record = MagicMock()
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+
+        try:
+            result_state = sync_contact_lists(STATE, ctx)
+
+            # Both bookmarks should be written
+            cl_bookmark = singer.get_bookmark(result_state, 'contact_lists', 'updatedAt')
+            lm_bookmark = singer.get_bookmark(result_state, 'list_memberships', 'membershipTimestamp')
+            self.assertIsNotNone(cl_bookmark)
+            self.assertIsNotNone(lm_bookmark)
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+
+
+class TestSyncContactListsChildStream(unittest.TestCase):
+    """
+    Tests for list_memberships child stream interaction.
+    """
+
+    @patch('tap_hubspot.sync_list_memberships')
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_list_memberships_called_for_all_records(self, mock_now, mock_load_schema, mock_post, mock_sync_memberships):
+        """
+        list_memberships should be synced for ALL records regardless of whether they
+        pass the bookmark filter (to ensure membership data is complete).
+        """
+        mock_now.return_value = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        def schema_side_effect(name):
+            return {
+                "type": "object",
+                "properties": {
+                    "listId": {"type": ["null", "string"]},
+                    "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                    "name": {"type": ["null", "string"]},
+                    "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                    "processingType": {"type": ["null", "string"]},
+                    "recordId": {"type": ["null", "string"]},
+                    "membershipTimestamp": {"type": ["null", "string"], "format": "date-time"},
+                }
+            }
+
+        mock_load_schema.side_effect = schema_side_effect
+        mock_sync_memberships.return_value = (
+            {"currently_syncing": "contact_lists", "bookmarks": {"contact_lists": {"updatedAt": "2024-04-01T00:00:00.000000Z"}}},
+            "2020-01-01T00:00:00Z"
+        )
+
+        desc_records = [
+            make_list_record(3, "2024-05-01T00:00:00Z"),  # newer than bookmark
+            make_list_record(2, "2024-04-01T00:00:00Z"),  # equal to bookmark
+            make_list_record(1, "2024-01-01T00:00:00Z"),  # older than bookmark
+        ]
+
+        mock_post.return_value = MockResponse(make_api_response(desc_records, has_more=False))
+
+        STATE = {
+            "currently_syncing": "contact_lists",
+            "bookmarks": {"contact_lists": {"updatedAt": "2024-04-01T00:00:00.000000Z"}}
+        }
+        ctx = MockContext(selected_stream_ids=["contact_lists", "list_memberships"])
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        original_write_record = singer.write_record
+        singer.write_record = MagicMock()
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+        original_write_bookmark = singer.write_bookmark
+        singer.write_bookmark = lambda state, stream, key, val: singer.bookmarks.write_bookmark(state, stream, key, val)
+
+        try:
+            sync_contact_lists(STATE, ctx)
+
+            # sync_list_memberships called for ALL 3 records (even the one older than bookmark)
+            self.assertEqual(mock_sync_memberships.call_count, 3)
+
+            # Verify it was called with correct list_ids
+            called_list_ids = [c[0][0] for c in mock_sync_memberships.call_args_list]
+            self.assertEqual(called_list_ids, ["3", "2", "1"])
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+            singer.write_bookmark = original_write_bookmark
+
+    @patch('tap_hubspot.sync_list_memberships')
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_list_memberships_not_called_when_not_selected(self, mock_now, mock_load_schema, mock_post, mock_sync_memberships):
+        """
+        list_memberships should NOT be called when it's not in selected_stream_ids.
+        """
+        mock_now.return_value = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_load_schema.return_value = {
+            "type": "object",
+            "properties": {
+                "listId": {"type": ["null", "string"]},
+                "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                "name": {"type": ["null", "string"]},
+                "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                "processingType": {"type": ["null", "string"]},
+            }
+        }
+
+        records = [make_list_record(1, "2024-05-01T00:00:00Z")]
+        mock_post.return_value = MockResponse(make_api_response(records, has_more=False))
+
+        STATE = {
+            "currently_syncing": "contact_lists",
+            "bookmarks": {"contact_lists": {"updatedAt": "2024-01-01T00:00:00.000000Z"}}
+        }
+        ctx = MockContext(selected_stream_ids=["contact_lists"])
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        original_write_record = singer.write_record
+        singer.write_record = MagicMock()
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+        original_write_bookmark = singer.write_bookmark
+        singer.write_bookmark = lambda state, stream, key, val: singer.bookmarks.write_bookmark(state, stream, key, val)
+
+        try:
+            sync_contact_lists(STATE, ctx)
+            mock_sync_memberships.assert_not_called()
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+            singer.write_bookmark = original_write_bookmark
+
+
+class TestSyncContactListsRequestBody(unittest.TestCase):
+    """
+    Tests verifying the request body sent to the API.
+    """
+
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_request_body_count_is_250(self, mock_now, mock_load_schema, mock_post):
+        """
+        Request body should always use count=250.
+        """
+        mock_now.return_value = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_load_schema.return_value = {
+            "type": "object",
+            "properties": {
+                "listId": {"type": ["null", "string"]},
+                "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                "name": {"type": ["null", "string"]},
+                "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                "processingType": {"type": ["null", "string"]},
+            }
+        }
+
+        mock_post.return_value = MockResponse(make_api_response([], has_more=False))
+
+        STATE = {
+            "currently_syncing": "contact_lists",
+            "bookmarks": {"contact_lists": {"updatedAt": "2024-01-01T00:00:00.000000Z"}}
+        }
+        ctx = MockContext()
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        original_write_record = singer.write_record
+        singer.write_record = MagicMock()
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+        original_write_bookmark = singer.write_bookmark
+        singer.write_bookmark = lambda state, stream, key, val: singer.bookmarks.write_bookmark(state, stream, key, val)
+
+        try:
+            sync_contact_lists(STATE, ctx)
+
+            call_body = mock_post.call_args_list[0][0][1]
+            self.assertEqual(call_body['count'], 250)
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+            singer.write_bookmark = original_write_bookmark
+
+
+class TestSyncContactListsStartUpdate(unittest.TestCase):
+    """
+    Tests for the `start = max_bk_value` logic between passes.
+    """
+
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_start_updated_between_passes_filters_desc_records(self, mock_now, mock_load_schema, mock_post):
+        """
+        After ascending pass, `start = max_bk_value` should prevent the descending pass
+        from writing records that were already emitted in the ascending pass.
+        """
+        mock_now.return_value = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_load_schema.return_value = {
+            "type": "object",
+            "properties": {
+                "listId": {"type": ["null", "string"]},
+                "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                "name": {"type": ["null", "string"]},
+                "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                "processingType": {"type": ["null", "string"]},
+            }
+        }
+
+        asc_records = [
+            make_list_record(1, "2024-01-01T00:00:00Z"),
+            make_list_record(2, "2024-02-01T00:00:00Z"),
+            make_list_record(3, "2024-03-01T00:00:00Z"),  # max_bk_value after asc pass
+        ]
+        desc_records = [
+            make_list_record(5, "2024-05-01T00:00:00Z"),  # new, >= start -> written
+            make_list_record(4, "2024-04-01T00:00:00Z"),  # new, >= start -> written
+            make_list_record(3, "2024-03-01T00:00:00Z"),  # boundary, >= start -> written (1 dup OK)
+            make_list_record(2, "2024-02-01T00:00:00Z"),  # < start -> NOT written
+            make_list_record(1, "2024-01-01T00:00:00Z"),  # < start -> NOT written
+        ]
+
+        mock_post.side_effect = [
+            MockResponse(make_api_response(asc_records, has_more=False)),
+            MockResponse(make_api_response(desc_records, has_more=False)),
+        ]
+
+        STATE = {"currently_syncing": "contact_lists", "bookmarks": {}}
+        ctx = MockContext()
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        written_records = []
+        original_write_record = singer.write_record
+        singer.write_record = lambda stream, record, *args, **kwargs: written_records.append(record)
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+        original_write_bookmark = singer.write_bookmark
+        singer.write_bookmark = lambda state, stream, key, val: singer.bookmarks.write_bookmark(state, stream, key, val)
+
+        try:
+            sync_contact_lists(STATE, ctx)
+
+            written_ids = [r['listId'] for r in written_records]
+
+            # Ascending pass: all 3 written (1, 2, 3)
+            # Descending pass: 5, 4, 3 written (>= "2024-03-01"); 2, 1 NOT written (< start)
+            # Total: 6 records written
+            self.assertEqual(len(written_records), 6)
+
+            # Records 1 and 2 should appear only once (from ascending)
+            self.assertEqual(written_ids.count("1"), 1)
+            self.assertEqual(written_ids.count("2"), 1)
+
+            # Record 3 appears twice (boundary) - acceptable
+            self.assertEqual(written_ids.count("3"), 2)
+
+            # Records 4 and 5 appear once (from descending)
+            self.assertEqual(written_ids.count("4"), 1)
+            self.assertEqual(written_ids.count("5"), 1)
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+            singer.write_bookmark = original_write_bookmark
+
+    @patch('tap_hubspot.post_search_endpoint')
+    @patch('tap_hubspot.load_schema')
+    @patch('tap_hubspot.utils.now')
+    def test_all_records_in_both_passes_when_total_under_10k(self, mock_now, mock_load_schema, mock_post):
+        """
+        When total records < 10K, both passes return ALL records.
+        The `start = max_bk_value` ensures desc pass doesn't re-emit records
+        already in the ascending pass (only boundary record may duplicate).
+        """
+        mock_now.return_value = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_load_schema.return_value = {
+            "type": "object",
+            "properties": {
+                "listId": {"type": ["null", "string"]},
+                "updatedAt": {"type": ["null", "string"], "format": "date-time"},
+                "name": {"type": ["null", "string"]},
+                "createdAt": {"type": ["null", "string"], "format": "date-time"},
+                "processingType": {"type": ["null", "string"]},
+            }
+        }
+
+        all_records_asc = [
+            make_list_record(1, "2024-01-01T00:00:00Z"),
+            make_list_record(2, "2024-02-01T00:00:00Z"),
+            make_list_record(3, "2024-03-01T00:00:00Z"),
+        ]
+        all_records_desc = [
+            make_list_record(3, "2024-03-01T00:00:00Z"),
+            make_list_record(2, "2024-02-01T00:00:00Z"),
+            make_list_record(1, "2024-01-01T00:00:00Z"),
+        ]
+
+        mock_post.side_effect = [
+            MockResponse(make_api_response(all_records_asc, has_more=False)),
+            MockResponse(make_api_response(all_records_desc, has_more=False)),
+        ]
+
+        STATE = {"currently_syncing": "contact_lists", "bookmarks": {}}
+        ctx = MockContext()
+        tap_hubspot.CONFIG['start_date'] = "2020-01-01T00:00:00Z"
+
+        written_records = []
+        original_write_record = singer.write_record
+        singer.write_record = lambda stream, record, *args, **kwargs: written_records.append(record)
+        original_write_schema = singer.write_schema
+        singer.write_schema = MagicMock()
+        original_write_state = singer.write_state
+        singer.write_state = MagicMock()
+        original_write_bookmark = singer.write_bookmark
+        singer.write_bookmark = lambda state, stream, key, val: singer.bookmarks.write_bookmark(state, stream, key, val)
+
+        try:
+            sync_contact_lists(STATE, ctx)
+
+            written_ids = [r['listId'] for r in written_records]
+
+            # Ascending: all 3 written. max_bk_value = "2024-03-01"
+            # Descending: only record 3 (>= "2024-03-01") written. Records 2, 1 filtered out.
+            # Total: 4 records (3 + 1 boundary duplicate)
+            self.assertEqual(len(written_records), 4)
+
+            # Only record 3 is duplicated (boundary)
+            self.assertEqual(written_ids.count("3"), 2)
+            self.assertEqual(written_ids.count("2"), 1)
+            self.assertEqual(written_ids.count("1"), 1)
+
+        finally:
+            singer.write_record = original_write_record
+            singer.write_schema = original_write_schema
+            singer.write_state = original_write_state
+            singer.write_bookmark = original_write_bookmark
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tap_hubspot/tests/unittests/test_request_timeout.py
+++ b/tap_hubspot/tests/unittests/test_request_timeout.py
@@ -112,6 +112,16 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
             Verify request function is backoff for only 5 times instead of 25 times on Timeout exception that thrown from `acquire_access_token_from_refresh_token` method.
             Here get_params_and_headers method called from request method and acquire_access_token_from_refresh_token called from get_params_and_headers method.
         """
+        tap_hubspot.CONFIG = {
+            'hapikey': None,
+            'api_key': None,
+            'token_expires': None,
+            'redirect_uri': 'https://example.com',
+            'refresh_token': 'dummy_refresh',
+            'client_id': 'dummy_client',
+            'client_secret': 'dummy_secret',
+            'request_timeout': 300,
+        }
         try:
             tap_hubspot.post_search_endpoint('dummy_url', {})
         except Exception:

--- a/tap_hubspot/tests/unittests/test_request_timeout.py
+++ b/tap_hubspot/tests/unittests/test_request_timeout.py
@@ -112,6 +112,7 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
             Verify request function is backoff for only 5 times instead of 25 times on Timeout exception that thrown from `acquire_access_token_from_refresh_token` method.
             Here get_params_and_headers method called from request method and acquire_access_token_from_refresh_token called from get_params_and_headers method.
         """
+        pre_config = tap_hubspot.CONFIG
         tap_hubspot.CONFIG = {
             'hapikey': None,
             'api_key': None,
@@ -126,6 +127,9 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
             tap_hubspot.post_search_endpoint('dummy_url', {})
         except Exception:
             pass
+        finally:
+            # Restore the original CONFIG after the test
+            tap_hubspot.CONFIG = pre_config
 
         # Verify that requests.post is called 5 times
         self.assertEqual(mocked_post.call_count, 5)

--- a/tests/base.py
+++ b/tests/base.py
@@ -171,35 +171,6 @@ class HubspotBaseTest(BaseCase):
                 self.EXPECTED_PAGE_SIZE: 100,
                 self.OBEYS_START_DATE: True
             },
-            # below are the custom_objects stream
-            "cars": {
-                self.PRIMARY_KEYS: {"id"},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"updatedAt"},
-                self.EXPECTED_PAGE_SIZE: 100,
-                self.OBEYS_START_DATE: True
-            },
-            "co_firsts": {
-                self.PRIMARY_KEYS: {"id"},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"updatedAt"},
-                self.EXPECTED_PAGE_SIZE: 100,
-                self.OBEYS_START_DATE: True
-            },
-            "custom_object_campaigns": {
-                self.PRIMARY_KEYS: {"id"},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"updatedAt"},
-                self.EXPECTED_PAGE_SIZE: 100,
-                self.OBEYS_START_DATE: True
-            },
-            "custom_object_contacts": {
-                self.PRIMARY_KEYS: {"id"},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"updatedAt"},
-                self.EXPECTED_PAGE_SIZE: 100,
-                self.OBEYS_START_DATE: True
-            }
         }
 
     #############################

--- a/tests/base_hubspot.py
+++ b/tests/base_hubspot.py
@@ -15,9 +15,7 @@ class HubspotBaseCase(BaseCase):
     # set the default start date which can be overridden in the tests.
     start_date = BaseCase.timedelta_formatted(dt.utcnow(), delta=timedelta(days=-1))
 
-    EXTRA_FIELDS = {
-        "contacts": { "versionTimestamp" }
-    }
+    EXTRA_FIELDS = {}
 
     def setUp(self):
         missing_envs = [x for x in [
@@ -156,38 +154,5 @@ class HubspotBaseCase(BaseCase):
                 BaseCase.API_LIMIT: 100,
                 BaseCase.OBEYS_START_DATE: True
             },
-            # below are the custom_objects stream
-            "cars": {
-                BaseCase.PRIMARY_KEYS: {"id"},
-                BaseCase.REPLICATION_METHOD: BaseCase.INCREMENTAL,
-                BaseCase.REPLICATION_KEYS: {"updatedAt"},
-                BaseCase.API_LIMIT: 100,
-                BaseCase.EXPECTED_PAGE_SIZE: 100,
-                BaseCase.OBEYS_START_DATE: True
-            },
-            "co_firsts": {
-                BaseCase.PRIMARY_KEYS: {"id"},
-                BaseCase.REPLICATION_METHOD: BaseCase.INCREMENTAL,
-                BaseCase.REPLICATION_KEYS: {"updatedAt"},
-                BaseCase.API_LIMIT: 100,
-                BaseCase.EXPECTED_PAGE_SIZE: 100,
-                BaseCase.OBEYS_START_DATE: True
-            },
-            "custom_object_campaigns": {
-                BaseCase.PRIMARY_KEYS: {"id"},
-                BaseCase.REPLICATION_METHOD: BaseCase.INCREMENTAL,
-                BaseCase.REPLICATION_KEYS: {"updatedAt"},
-                BaseCase.API_LIMIT: 100,
-                BaseCase.EXPECTED_PAGE_SIZE: 100,
-                BaseCase.OBEYS_START_DATE: True
-            },
-            "custom_object_contacts": {
-                BaseCase.PRIMARY_KEYS: {"id"},
-                BaseCase.REPLICATION_METHOD: BaseCase.INCREMENTAL,
-                BaseCase.REPLICATION_KEYS: {"updatedAt"},
-                BaseCase.API_LIMIT: 100,
-                BaseCase.EXPECTED_PAGE_SIZE: 100,
-                BaseCase.OBEYS_START_DATE: True
-            }
 
         }

--- a/tests/client.py
+++ b/tests/client.py
@@ -1010,8 +1010,12 @@ class TestClient():
             url = f"{BASE_URL}/crm/v3/lists/{list_id}/memberships/add"
             data = ["462631815886", "462622843639"]
             LOGGER.info("Post URL is %s", url)
-            # generate a record
-            self.put(url, data)
+            try:
+                # generate a record
+                self.put(url, data)
+            except requests.exceptions.HTTPError as err:
+                LOGGER.debug("Update failed for %s", list_id)
+                continue
             records.extend([{'listId': list_id, 'recordId': '462631815886'}, {'listId': list_id, 'recordId': '462622843639'}])
         return records
 

--- a/tests/client.py
+++ b/tests/client.py
@@ -872,7 +872,7 @@ class TestClient():
             "description": "A new number property for you",
             "groupName": "contactinformation",
             "type": "number",
-            "fieldType": "text",
+            "fieldType": "number",
             "formField": True,
             "displayOrder": 7,
             "options": [
@@ -886,7 +886,7 @@ class TestClient():
             "description": "A new date property for you",
             "groupName": "contactinformation",
             "type": "date",
-            "fieldType": "text",
+            "fieldType": "date",
             "formField": True,
             "displayOrder": 9,
             "options": [
@@ -900,7 +900,7 @@ class TestClient():
             "description": "A new datetime property for you",
             "groupName": "contactinformation",
             "type": "datetime",
-            "fieldType": "text",
+            "fieldType": "date",
             "formField": True,
             "displayOrder": 10,
             "options": [
@@ -1008,11 +1008,11 @@ class TestClient():
         records = []
         for list_id in list_ids:
             url = f"{BASE_URL}/crm/v3/lists/{list_id}/memberships/add"
-            data = ["318001", "199564445797"]
+            data = ["462631815886", "462622843639"]
             LOGGER.info("Post URL is %s", url)
             # generate a record
             self.put(url, data)
-            records.extend([{'listId': list_id, 'recordId': '318041'}, {'listId': list_id, 'recordId': '199564445797'}])
+            records.extend([{'listId': list_id, 'recordId': '462631815886'}, {'listId': list_id, 'recordId': '462622843639'}])
         return records
 
     def create_contact_lists(self, dynamic=True):
@@ -1232,10 +1232,10 @@ class TestClient():
         data = {
             "associations": {
                 "associatedCompanyIds": [
-                    6804176293
+                    130787345085
                 ],
                 "associatedVids": [
-                    2304
+                    123338799847
                 ]
             },
             "properties": [
@@ -1252,7 +1252,7 @@ class TestClient():
                     "name": "pipeline"
                 },
                 {
-                    "value": "98621200",
+                    "value": "79930367",
                     "name": "hubspot_owner_id"
                 },
                 {
@@ -1327,22 +1327,17 @@ class TestClient():
         data = {
             "engagement": {
                 "active": True,
-                "ownerId": 98621200,
+                "ownerId": 79930367,
                 "type": "NOTE",
                 "timestamp": 1409172644778
             },
             "associations": {
                 "contactIds": [contact_id],
-                "companyIds": [6804176293],
+                "companyIds": [130787345085],
                 "dealIds": [],
                 "ownerIds": [],
                 "ticketIds": []
             },
-            "attachments": [
-                {
-                    "id": 4241968539
-                }
-            ],
             "metadata": {
                 "body": "note body"
             }
@@ -1949,7 +1944,6 @@ class TestClient():
         """
         payload = {
             "grant_type": "refresh_token",
-            "redirect_uri": self.CONFIG['redirect_uri'],
             "refresh_token": self.CONFIG['refresh_token'],
             "client_id": self.CONFIG['client_id'],
             "client_secret": self.CONFIG['client_secret'],

--- a/tests/test_hubspot_all_fields.py
+++ b/tests/test_hubspot_all_fields.py
@@ -166,6 +166,7 @@ class TestHubspotAllFields(HubspotBaseTest):
         return self.expected_streams().difference({
             'owners',
             'subscription_changes', # BUG_TDL-14938 https://jira.talendforge.org/browse/TDL-14938
+            'workflows'
         })
 
     def setUp(self):

--- a/tests/test_hubspot_automatic_fields.py
+++ b/tests/test_hubspot_automatic_fields.py
@@ -87,13 +87,25 @@ class TestHubspotAutomaticFields(HubspotBaseTest):
                     )
 
 
+                pk = self.expected_primary_keys()[stream]
+                pks_values = [tuple([message['data'][p] for p in pk]) for message in data['messages']]
+
+                if stream == 'contact_lists':
+                    # We run sync twice in case of historic sync - One in asc order and another in desc order.
+                    # Find more details in PR: https://github.com/singer-io/tap-hubspot/pull/304
+                    # So we expect to see 1 boundary record in both syncs
+                    self.assertEqual(len(pks_values), len(set(pks_values))+1)
+                    continue
+
+                if stream == 'list_memberships':
+                    # So we expect to see 2 boundary record in both syncs since it is child stream of contact_lists
+                    self.assertEqual(len(pks_values), len(set(pks_values))+2)
+                    continue
+
                 # BUG_TDL-14938 https://jira.talendforge.org/browse/TDL-14938
                 #               The subscription_changes stream does not have a valid pk to ensure no dupes are sent
                 if stream != 'subscription_changes':
-
                     # make sure there are no duplicate records by using the pks
-                    pk = self.expected_primary_keys()[stream]
-                    pks_values = [tuple([message['data'][p] for p in pk]) for message in data['messages']]
                     self.assertEqual(len(pks_values), len(set(pks_values)))
 
 

--- a/tests/test_hubspot_automatic_fields.py
+++ b/tests/test_hubspot_automatic_fields.py
@@ -15,7 +15,7 @@ class TestHubspotAutomaticFields(HubspotBaseTest):
 
     def streams_to_test(self):
         """streams to test"""
-        return self.expected_streams() - STATIC_DATA_STREAMS - {'form_submissions'}
+        return self.expected_streams() - STATIC_DATA_STREAMS - {'form_submissions', 'workflows'}
 
     def test_run(self):
         """

--- a/tests/test_hubspot_newfw_all_fields.py
+++ b/tests/test_hubspot_newfw_all_fields.py
@@ -18,6 +18,9 @@ class HubspotAllFieldsTest(AllFieldsTest, HubspotBaseCase):
             'owners',
             'form_submissions',
             'subscription_changes', # BUG_TDL-14938 https://jira.talendforge.org/browse/TDL-14938
+            # No records are returned in this account for this test window.
+            'workflows',
+            'email_events'
         })
 
     def setUp(self):
@@ -27,17 +30,21 @@ class HubspotAllFieldsTest(AllFieldsTest, HubspotBaseCase):
 
         self.expected_records = dict()
         streams = self.streams_to_test()
-        stream_to_run_last = 'contacts_by_company'
-        if stream_to_run_last in streams:
-            streams.remove(stream_to_run_last)
-            streams = list(streams)
-            streams.append(stream_to_run_last)
+
+        # move child streams to the end of the list so parent ids are pre-populated by test client
+        child_streams = ['contacts_by_company', 'list_memberships']
+        streams = list(set(streams) - set(child_streams))
+        streams.extend(child_streams)
 
         for stream in streams:
             # Get all records
             if stream == 'contacts_by_company':
                 company_ids = [company['companyId'] for company in self.expected_records['companies']]
                 self.expected_records[stream] = test_client.read(stream, parent_ids=company_ids)
+            elif stream == 'list_memberships':
+                list_ids = [contact_list['listId'] for contact_list in self.expected_records.get(
+                    'contact_lists', [])]
+                self.expected_records[stream] = test_client.read(stream, parent_ids=list_ids)
             else:
                 self.expected_records[stream] = test_client.read(stream)
 
@@ -74,7 +81,8 @@ class HubspotAllFieldsTest(AllFieldsTest, HubspotBaseCase):
         # BUG_TDL-14993 | https://jira.talendforge.org/browse/TDL-14993
         #                 Has an value of object with key 'value' and value 'Null'
         if stream == 'deals':
-            bad_key_prefixes = {'property_hs_date_entered_', 'property_hs_date_exited_', 'property_hs_time_in'}
+            bad_key_prefixes = {'property_hs_date_entered_', 'property_hs_date_exited_', 'property_hs_time_in',
+                                'property_hs_v2_date_entered_', 'property_hs_v2_date_exited_', 'property_hs_v2_latest_time'}
             bad_keys = set()
             for key in self.expected_all_keys:
                 for bad_prefix in bad_key_prefixes:

--- a/tests/test_hubspot_start_date.py
+++ b/tests/test_hubspot_start_date.py
@@ -29,10 +29,16 @@ class TestHubspotStartDate(HubspotBaseTest):
         self.my_start_date = self.get_properties()['start_date']
         self.test_client = TestClient(self.my_start_date)
         for stream in streams_under_test:
+            records = self.test_client.read(stream, since=self.my_start_date)
+            if len(records) > 3:
+                continue
             if stream == 'contacts_by_company':
                 companies_records = self.test_client.read('companies', since=self.my_start_date)
                 company_ids = [company['companyId'] for company in companies_records]
                 self.test_client.create(stream, company_ids)
+            elif stream == 'list_memberships':
+                list_ids = [contact_list['listId'] for contact_list in self.test_client.read('contact_lists', since=self.my_start_date)]
+                self.test_client.create(stream, list_ids=list_ids)
             else:
                 self.test_client.create(stream)
 
@@ -45,7 +51,6 @@ class TestHubspotStartDate(HubspotBaseTest):
         return self.expected_check_streams().difference({
             'owners', # static test data, covered in separate test
             'form_submissions',
-            'list_memberships',
             'workflows',
             'campaigns', # static test data, covered in separate test
         })
@@ -153,26 +158,26 @@ class TestHubspotStartDate(HubspotBaseTest):
                 self.assertGreater(second_sync_count, 0,
                                    msg='start date usage is not confirmed when no records are replicated')
 
-# class TestHubspotStartDateStatic(TestHubspotStartDate):
-#     @staticmethod
-#     def name():
-#         return "tt_hubspot_start_date_static"
+class TestHubspotStartDateStatic(TestHubspotStartDate):
+    @staticmethod
+    def name():
+        return "tt_hubspot_start_date_static"
 
-#     def expected_streams(self):
-#         """expected streams minus the streams not under test"""
-#         return {
-#             'owners',
-#             'campaigns',
-#         }
+    def expected_streams(self):
+        """expected streams minus the streams not under test"""
+        return {
+            'owners',
+            'campaigns',
+        }
 
-#     def get_properties(self, original=True):
-#         if original:
-#             return {'start_date' : '2017-11-22T00:00:00Z'}
+    def get_properties(self, original=True):
+        if original:
+            return {'start_date' : '2017-11-22T00:00:00Z'}
 
-#         else:
-#             return {
-#                 'start_date' : '2026-02-25T00:00:00Z'
-#             }
+        else:
+            return {
+                'start_date' : '2026-02-25T00:00:00Z'
+            }
 
-#     def setUp(self):
-#         LOGGER.info("running streams with no creates")
+    def setUp(self):
+        LOGGER.info("running streams with no creates")

--- a/tests/test_hubspot_start_date.py
+++ b/tests/test_hubspot_start_date.py
@@ -25,7 +25,7 @@ class TestHubspotStartDate(HubspotBaseTest):
         """
 
         LOGGER.info("running streams with creates")
-        streams_under_test = self.expected_streams() - {'email_events'} # we get this for free with subscription_changes
+        streams_under_test = self.expected_streams() - {'email_events', 'workflows'} # we get this for free with subscription_changes
         self.my_start_date = self.get_properties()['start_date']
         self.test_client = TestClient(self.my_start_date)
         for stream in streams_under_test:
@@ -46,6 +46,7 @@ class TestHubspotStartDate(HubspotBaseTest):
             'owners', # static test data, covered in separate test
             'form_submissions',
             'list_memberships',
+            'workflows',
             'campaigns', # static test data, covered in separate test
         })
 
@@ -61,7 +62,7 @@ class TestHubspotStartDate(HubspotBaseTest):
             }
         else:
             return {
-                'start_date': self.timedelta_formatted(utc_today, days=-3)
+                'start_date': self.timedelta_formatted(utc_today, days=-1)
             }
 
     def test_run(self):
@@ -152,26 +153,26 @@ class TestHubspotStartDate(HubspotBaseTest):
                 self.assertGreater(second_sync_count, 0,
                                    msg='start date usage is not confirmed when no records are replicated')
 
-class TestHubspotStartDateStatic(TestHubspotStartDate):
-    @staticmethod
-    def name():
-        return "tt_hubspot_start_date_static"
+# class TestHubspotStartDateStatic(TestHubspotStartDate):
+#     @staticmethod
+#     def name():
+#         return "tt_hubspot_start_date_static"
 
-    def expected_streams(self):
-        """expected streams minus the streams not under test"""
-        return {
-            'owners',
-            'campaigns',
-        }
+#     def expected_streams(self):
+#         """expected streams minus the streams not under test"""
+#         return {
+#             'owners',
+#             'campaigns',
+#         }
 
-    def get_properties(self, original=True):
-        if original:
-            return {'start_date' : '2017-11-22T00:00:00Z'}
+#     def get_properties(self, original=True):
+#         if original:
+#             return {'start_date' : '2017-11-22T00:00:00Z'}
 
-        else:
-            return {
-                'start_date' : '2023-02-25T00:00:00Z'
-            }
+#         else:
+#             return {
+#                 'start_date' : '2026-02-25T00:00:00Z'
+#             }
 
-    def setUp(self):
-        LOGGER.info("running streams with no creates")
+#     def setUp(self):
+#         LOGGER.info("running streams with no creates")


### PR DESCRIPTION
# Description of change
HubSpot's `/crm/v3/lists/search` [endpoint](https://developers.hubspot.com/docs/api-reference/latest/crm/lists/search/search-lists) enforces a hard [10,000 record offset ceiling](https://developers.hubspot.com/docs/api-reference/latest/crm/search-the-crm#:~:text=The%20search%20endpoints%20are%20limited%20to%2010%2C000%20total%20results%20for%20any%20given%20query.%20Attempting%20to%20page%20beyond%2010%2C000%20will%20result%20in%20a%20400%20error.). It does not return records beyond that. There is no other endpoint available that can replace it.

To maximize coverage:
  - Historic sync (no bookmark): Fetch in BOTH ascending and descending order of `HS_UPDATED_AT`. This gives up to ~20K unique records. After the ascending pass, `start` is updated to `max_bk_value` so the descending pass only emits records newer than what was already seen, effectively deduplicating (with at most 1 record overlap at the boundary).
  - From next sync onwards: Fetch only in descending order (`-HS_UPDATED_AT`). This retrieves the latest 10K updated records.


# Manual QA steps
 - Run the historic sync and verified that it sync contact_lists in `asc` and `desc` order of `updated_at`.
 - Run the historic sync and verified that it does not sync duplicate records.
 - Run the next sync and verified that it sync contact_lists `desc` order only.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
